### PR TITLE
Remove duplicated check

### DIFF
--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -631,12 +631,6 @@ na_get_pointer_for_rw(VALUE self, int flag)
         if ((flag & WRITE) && OBJ_FROZEN(obj)) {
             rb_raise(rb_eRuntimeError, "cannot write to frozen NArray.");
         }
-
-        if (flag & WRITE) {
-            if (OBJ_FROZEN(obj)) {
-                rb_raise(rb_eRuntimeError, "cannot write to frozen NArray.");
-            }
-        }
         GetNArray(obj,na);
         switch(NA_TYPE(na)) {
         case NARRAY_DATA_T:


### PR DESCRIPTION
I found the check of writing to a frozen object is duplicated.