### PR TITLE
Add static to functions that not necessary to be exported

### DIFF
--- a/ext/numo/narray/data.c
+++ b/ext/numo/narray/data.c
@@ -57,7 +57,7 @@ static ID id_swap_byte;
 }
 
 #define m_memcpy(src,dst) memcpy(dst,src,e)
-void
+static void
 iter_copy_bytes(na_loop_t *const lp)
 {
     size_t e;
@@ -206,7 +206,7 @@ check_axis(int axis, int ndim)
     #  [[1, 5],
     #   [3, 7]]]
 */
-VALUE
+static VALUE
 na_swapaxes(VALUE self, VALUE a1, VALUE a2)
 {
     int  i, j, ndim;
@@ -232,7 +232,7 @@ na_swapaxes(VALUE self, VALUE a1, VALUE a2)
     return view;
 }
 
-VALUE
+static VALUE
 na_transpose_map(VALUE self, int *map)
 {
     int  i, ndim;
@@ -262,7 +262,7 @@ na_transpose_map(VALUE self, int *map)
 
 #define SWAP(a,b,tmp) {tmp=a;a=b;b=tmp;}
 
-VALUE
+static VALUE
 na_transpose(int argc, VALUE *argv, VALUE self)
 {
     int ndim, *map, *permute;
@@ -591,7 +591,7 @@ na_flatten(VALUE self)
      [10, 11, 12, 3, 14],
      [15, 16, 17, 18, 4]]
  */
-VALUE
+static VALUE
 na_diagonal(int argc, VALUE *argv, VALUE self)
 {
     int  i, k, nd;

--- a/ext/numo/narray/gen/tmpl/alloc_func.c
+++ b/ext/numo/narray/gen/tmpl/alloc_func.c
@@ -70,7 +70,7 @@ static void
     }
 }
 
-const rb_data_type_t <%=type_name%>_data_type = {
+static const rb_data_type_t <%=type_name%>_data_type = {
     "<%=full_class_name%>",
     {<%=type_name%>_gc_mark, <%=type_name%>_free, <%=type_name%>_memsize,},
     &na_data_type,
@@ -80,7 +80,7 @@ const rb_data_type_t <%=type_name%>_data_type = {
 
 <% else %>
 
-const rb_data_type_t <%=type_name%>_data_type = {
+static const rb_data_type_t <%=type_name%>_data_type = {
     "<%=full_class_name%>",
     {0, <%=type_name%>_free, <%=type_name%>_memsize,},
     &na_data_type,
@@ -90,7 +90,7 @@ const rb_data_type_t <%=type_name%>_data_type = {
 
 <% end %>
 
-VALUE
+static VALUE
 <%=c_func(0)%>(VALUE klass)
 {
     narray_data_t *na = ALLOC(narray_data_t);

--- a/ext/numo/narray/gen/tmpl/each.c
+++ b/ext/numo/narray/gen/tmpl/each.c
@@ -1,4 +1,4 @@
-void
+static void
 <%=c_iter%>(na_loop_t *const lp)
 {
     size_t i, s1;

--- a/ext/numo/narray/gen/tmpl/each_with_index.c
+++ b/ext/numo/narray/gen/tmpl/each_with_index.c
@@ -11,7 +11,7 @@ yield_each_with_index(dtype x, size_t *c, VALUE *a, int nd, int md)
 }
 
 
-void
+static void
 <%=c_iter%>(na_loop_t *const lp)
 {
     size_t i, s1;

--- a/ext/numo/narray/gen/tmpl/inspect.c
+++ b/ext/numo/narray/gen/tmpl/inspect.c
@@ -13,7 +13,7 @@ static VALUE
   @overload inspect
   @return [String]
 */
-VALUE
+static VALUE
 <%=c_func(0)%>(VALUE ary)
 {
     return na_ndloop_inspect(ary, <%=c_iter%>, Qnil);

--- a/ext/numo/narray/gen/tmpl/map_with_index.c
+++ b/ext/numo/narray/gen/tmpl/map_with_index.c
@@ -12,7 +12,7 @@ yield_map_with_index(dtype x, size_t *c, VALUE *a, int nd, int md)
     return m_num_to_data(y);
 }
 
-void
+static void
 <%=c_iter%>(na_loop_t *const lp)
 {
     size_t  i;

--- a/ext/numo/narray/gen/tmpl/qsort.c
+++ b/ext/numo/narray/gen/tmpl/qsort.c
@@ -76,7 +76,7 @@
 <% end %>
 <% c_func(:nodef)%>
 
-void
+static void
 <%=type_name%>_qsort<%=suffix%>(void *a, size_t n, ssize_t es)
 {
     char *pa, *pb, *pc, *pd, *pl, *pm, *pn;

--- a/ext/numo/narray/gen/tmpl/to_a.c
+++ b/ext/numo/narray/gen/tmpl/to_a.c
@@ -1,4 +1,4 @@
-void
+static void
 <%=c_iter%>(na_loop_t *const lp)
 {
     size_t i, s1;

--- a/ext/numo/narray/gen/tmpl_bit/each.c
+++ b/ext/numo/narray/gen/tmpl_bit/each.c
@@ -1,4 +1,4 @@
-void
+static void
 <%=c_iter%>(na_loop_t *const lp)
 {
     size_t   i;

--- a/ext/numo/narray/gen/tmpl_bit/each_with_index.c
+++ b/ext/numo/narray/gen/tmpl_bit/each_with_index.c
@@ -11,7 +11,7 @@ yield_each_with_index(dtype x, size_t *c, VALUE *a, int nd, int md)
 }
 
 
-void
+static void
 <%=c_iter%>(na_loop_t *const lp)
 {
     size_t   i;

--- a/ext/numo/narray/gen/tmpl_bit/inspect.c
+++ b/ext/numo/narray/gen/tmpl_bit/inspect.c
@@ -11,7 +11,7 @@ static VALUE
   @overload inspect
   @return [String]
 */
-VALUE
+static VALUE
 <%=c_func(0)%>(VALUE ary)
 {
     return na_ndloop_inspect(ary, <%=c_iter%>, Qnil);

--- a/ext/numo/narray/gen/tmpl_bit/to_a.c
+++ b/ext/numo/narray/gen/tmpl_bit/to_a.c
@@ -1,4 +1,4 @@
-void
+static void
 <%=c_iter%>(na_loop_t *const lp)
 {
     size_t     i;

--- a/ext/numo/narray/index.c
+++ b/ext/numo/narray/index.c
@@ -82,7 +82,7 @@ static ID id_shift_left;
 static ID id_mask;
 
 
-void
+static void
 na_index_set_step(na_index_arg_t *q, int i, size_t n, size_t beg, ssize_t step)
 {
     q->n    = n;
@@ -93,7 +93,7 @@ na_index_set_step(na_index_arg_t *q, int i, size_t n, size_t beg, ssize_t step)
     q->orig_dim = i;
 }
 
-void
+static void
 na_index_set_scalar(na_index_arg_t *q, int i, ssize_t size, ssize_t x)
 {
     if (x < -size || x >= size)
@@ -610,7 +610,7 @@ na_aref_md_ensure(VALUE data_value)
     return Qnil;
 }
 
-VALUE
+static VALUE
 na_aref_md(int argc, VALUE *argv, VALUE self, int keep_dim, int result_nd)
 {
     VALUE args; // should be GC protected

--- a/ext/numo/narray/math.c
+++ b/ext/numo/narray/math.c
@@ -14,7 +14,7 @@ static ID id_UPCAST;
 static ID id_DISPATCH;
 static ID id_extract;
 
-VALUE
+static VALUE
 nary_type_s_upcast(VALUE type1, VALUE type2)
 {
     VALUE upcast_hash;
@@ -35,7 +35,7 @@ nary_type_s_upcast(VALUE type1, VALUE type2)
 }
 
 
-VALUE nary_math_cast2(VALUE type1, VALUE type2)
+static VALUE nary_math_cast2(VALUE type1, VALUE type2)
 {
     if ( RTEST(rb_class_inherited_p( type1, cNArray )) ){
 	return nary_type_s_upcast( type1, type2 );
@@ -57,7 +57,7 @@ VALUE nary_math_cast2(VALUE type1, VALUE type2)
 
 VALUE na_ary_composition_dtype(VALUE);
 
-VALUE nary_mathcast(int argc, VALUE *argv)
+static VALUE nary_mathcast(int argc, VALUE *argv)
 {
     VALUE type, type2;
     int i;
@@ -82,7 +82,7 @@ VALUE nary_mathcast(int argc, VALUE *argv)
   @param [NArray,Numeric] x  input array.
   @return [NArray] result.
 */
-VALUE nary_math_method_missing(int argc, VALUE *argv, VALUE mod)
+static VALUE nary_math_method_missing(int argc, VALUE *argv, VALUE mod)
 {
     VALUE type, ans, typemod, hash;
     if (argc>1) {

--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -965,7 +965,7 @@ na_make_view(VALUE self)
  *  @param [Integer] dim  dimension at which new axis is inserted.
  *  @return [Numo::NArray]  result narray view.
  */
-VALUE
+static VALUE
 na_expand_dims(VALUE self, VALUE vdim)
 {
     int  i, j, nd, dim;
@@ -1024,7 +1024,7 @@ na_expand_dims(VALUE self, VALUE vdim)
  *
  *  Return reversed view along specified dimeinsion
  */
-VALUE
+static VALUE
 nary_reverse(int argc, VALUE *argv, VALUE self)
 {
     int i, nd;
@@ -1362,7 +1362,7 @@ nary_marshal_dump(VALUE self)
     return a;
 }
 
-VALUE na_inplace( VALUE self );
+static VALUE na_inplace( VALUE self );
 /*
   Load marshal data.
   @overload marshal_load(data)
@@ -1609,7 +1609,7 @@ nary_reduce_dimension(int argc, VALUE *argv, int naryc, VALUE *naryv,
 /*
   Return true if column major.
 */
-VALUE na_column_major_p( VALUE self )
+static VALUE na_column_major_p( VALUE self )
 {
     if (TEST_COLUMN_MAJOR(self))
 	return Qtrue;
@@ -1620,7 +1620,7 @@ VALUE na_column_major_p( VALUE self )
 /*
   Return true if row major.
 */
-VALUE na_row_major_p( VALUE self )
+static VALUE na_row_major_p( VALUE self )
 {
     if (TEST_ROW_MAJOR(self))
 	return Qtrue;
@@ -1632,7 +1632,7 @@ VALUE na_row_major_p( VALUE self )
 /*
   Return true if byte swapped.
 */
-VALUE na_byte_swapped_p( VALUE self )
+static VALUE na_byte_swapped_p( VALUE self )
 {
     if (TEST_BYTE_SWAPPED(self))
       return Qtrue;
@@ -1642,7 +1642,7 @@ VALUE na_byte_swapped_p( VALUE self )
 /*
   Return true if not byte swapped.
 */
-VALUE na_host_order_p( VALUE self )
+static VALUE na_host_order_p( VALUE self )
 {
     if (TEST_BYTE_SWAPPED(self))
       return Qfalse;
@@ -1654,7 +1654,7 @@ VALUE na_host_order_p( VALUE self )
   Returns view of narray with inplace flagged.
   @return [Numo::NArray] view of narray with inplace flag.
 */
-VALUE na_inplace( VALUE self )
+static VALUE na_inplace( VALUE self )
 {
     VALUE view = self;
     view = na_make_view(self);
@@ -1666,7 +1666,7 @@ VALUE na_inplace( VALUE self )
   Set inplace flag to self.
   @return [Numo::NArray] self
 */
-VALUE na_inplace_bang( VALUE self )
+static VALUE na_inplace_bang( VALUE self )
 {
     SET_INPLACE(self);
     return self;
@@ -1683,7 +1683,7 @@ VALUE na_inplace_store( VALUE self, VALUE val )
 /*
   Return true if inplace flagged.
 */
-VALUE na_inplace_p( VALUE self )
+static VALUE na_inplace_p( VALUE self )
 {
     if (TEST_INPLACE(self))
         return Qtrue;
@@ -1695,7 +1695,7 @@ VALUE na_inplace_p( VALUE self )
   Unset inplace flag to self.
   @return [Numo::NArray] self
 */
-VALUE na_out_of_place_bang( VALUE self )
+static VALUE na_out_of_place_bang( VALUE self )
 {
     UNSET_INPLACE(self);
     return self;
@@ -1791,7 +1791,7 @@ static VALUE na_inspect_cols_set(VALUE mod, VALUE num)
   @param [Object] other
   @return [Boolean] true if self and other is equal.
 */
-VALUE
+static VALUE
 na_equal(VALUE self, volatile VALUE other)
 {
     volatile VALUE vbool;

--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -1672,14 +1672,6 @@ static VALUE na_inplace_bang( VALUE self )
     return self;
 }
 
-VALUE na_inplace_store( VALUE self, VALUE val )
-{
-    if (self==val)
-        return self;
-    else
-        return na_store( self, val );
-}
-
 /*
   Return true if inplace flagged.
 */

--- a/ext/numo/narray/ndloop.c
+++ b/ext/numo/narray/ndloop.c
@@ -1389,7 +1389,7 @@ loop_narray(ndfunc_t *nf, na_md_loop_t *lp)
 }
 
 
-VALUE
+static VALUE
 na_ndloop_main(ndfunc_t *nf, VALUE args, void *opt_ptr)
 {
     unsigned int copy_flag;

--- a/ext/numo/narray/rand.c
+++ b/ext/numo/narray/rand.c
@@ -10,35 +10,8 @@
 #include <sys/time.h>
 #endif
 
-int n_bits(u_int64_t a)
-{
-    int i, x, /*xu,*/ xl, n=5;
-    u_int64_t m;
-
-    if (a==0) return 0;
-    //if (a<0) a=-a;
-
-    x  = 1<<n;
-    //xu = 1<<(n+1);
-    xl = 0;
-    //printf("%3i, [%3i, %3i], %i\n", i, xu, xl, x);
-
-    for (i=n; i>=0; i--) {
-	m = ~((1<<(x-1))-1);
-	if (m & a) {
-	    xl = x;
-	    x += 1<<(i-1);
-	} else {
-	    //xu = x;
-	    x -= 1<<(i-1);
-	}
-	//printf("%3i, [%3i, %3i], %i, 0x%lx, 0x%lx\n", i, xu, xl, x, m, m&a);
-    }
-    return xl;
-}
-
 static u_int64_t
- random_seed()
+random_seed()
 {
     static int n = 0;
     struct timeval tv;
@@ -48,7 +21,7 @@ static u_int64_t
 }
 
 static VALUE
- nary_s_srand(int argc, VALUE *argv, VALUE obj)
+nary_s_srand(int argc, VALUE *argv, VALUE obj)
 {
     VALUE vseed;
     u_int64_t seed;

--- a/ext/numo/narray/step.c
+++ b/ext/numo/narray/step.c
@@ -71,7 +71,7 @@ nary_step_new(
     return self;
 }
 
-VALUE
+static VALUE
 nary_step_new2(
   VALUE range,
   VALUE step,

--- a/ext/numo/narray/step.c
+++ b/ext/numo/narray/step.c
@@ -56,21 +56,6 @@ step_init(
     SET_EXCL(self, excl);
 }
 
-VALUE
-nary_step_new(
-  VALUE beg,
-  VALUE end,
-  VALUE step,
-  VALUE len,
-  VALUE excl
-)
-{
-    VALUE self = rb_obj_alloc(na_cStep);
-
-    step_init(self, beg, end, step, len, excl);
-    return self;
-}
-
 static VALUE
 nary_step_new2(
   VALUE range,
@@ -453,18 +438,6 @@ nary_s_step( int argc, VALUE *argv, VALUE mod )
     step_initialize(argc, argv, self);
     return self;
 }
-
-
-VALUE
-nary_is_sequence( VALUE arg )
-{
-    if ( rb_obj_is_kind_of(arg, rb_cRange) )
-        return Qtrue;
-    if ( rb_obj_is_kind_of(arg, na_cStep) )
-        return Qtrue;
-    return Qfalse;
-}
-
 
 
 void

--- a/ext/numo/narray/struct.c
+++ b/ext/numo/narray/struct.c
@@ -76,7 +76,7 @@ nst_definition(VALUE nst, VALUE idx)
 
 void na_copy_array_structure(VALUE self, VALUE view);
 
-VALUE
+static VALUE
 na_make_view_struct(VALUE self, VALUE dtype, VALUE offset)
 {
     size_t i, n;
@@ -172,7 +172,7 @@ na_make_view_struct(VALUE self, VALUE dtype, VALUE offset)
 }
 
 
-VALUE
+static VALUE
 nst_field_view(VALUE self, VALUE idx)
 {
     VALUE def, type, ofs;
@@ -188,7 +188,7 @@ nst_field_view(VALUE self, VALUE idx)
     return na_make_view_struct(self, type, ofs);
 }
 
-VALUE
+static VALUE
 nst_field(VALUE self, VALUE idx)
 {
     VALUE obj;
@@ -202,7 +202,7 @@ nst_field(VALUE self, VALUE idx)
     return obj;
 }
 
-VALUE
+static VALUE
 nst_field_set(VALUE self, VALUE idx, VALUE other)
 {
     VALUE obj;
@@ -785,7 +785,7 @@ iter_struct_inspect(char *ptr, size_t pos, VALUE opt)
   @overload inspect
   @return [String]
 */
-VALUE
+static VALUE
 nary_struct_inspect(VALUE ary)
 {
     VALUE opt;

--- a/ext/numo/narray/struct.c
+++ b/ext/numo/narray/struct.c
@@ -519,6 +519,7 @@ check_array_1d(VALUE item, size_t size) {
     return 0;
 }
 
+/*
 VALUE
 nst_check_compatibility(VALUE nst, VALUE ary)
 {
@@ -579,7 +580,7 @@ nst_check_compatibility(VALUE nst, VALUE ary)
     }
     return Qtrue;
 }
-
+*/
 
 
 VALUE na_ary_composition_for_struct(VALUE nstruct, VALUE ary);

--- a/ext/numo/narray/struct.c
+++ b/ext/numo/narray/struct.c
@@ -491,6 +491,7 @@ check_array(VALUE item) {
     return 0;
 }
 
+/*
 static size_t
 check_array_1d(VALUE item, size_t size) {
     narray_t *na;
@@ -518,6 +519,7 @@ check_array_1d(VALUE item, size_t size) {
     }
     return 0;
 }
+*/
 
 /*
 VALUE


### PR DESCRIPTION
and remove unused functions.

This is a kind of **feedbacks** from Cumo to Numo.

# Background

I am currently creating CUDA-aware version of Numo, https://github.com/sonots/cumo.
I want to support conversion from Numo::NArray into Cumo::NArray.

To do it, I needed to support `require "numo/narray.so"` anyway.
I needed to resolve C symbol collisions between Numo and Cumo.

# What this PR does

While working to resolve symbol conflictions, I noticed that some functions are not used from outside of its file. So, I put `static` for them. I also found that some C functions are even not used from anywhere. So, I removed them.

# See also

https://github.com/sonots/cumo/pull/48
