### PR TITLE
Broadcast performance improvement.

### DIFF
--- a/ext/numo/narray/gen/tmpl/binary.c
+++ b/ext/numo/narray/gen/tmpl/binary.c
@@ -29,9 +29,16 @@ static void
             s2 == sizeof(dtype) &&
             s3 == sizeof(dtype) ) {
 
-            for (i=0; i<n; i++) {
-                check_intdivzero(*(dtype*)p2);
-                ((dtype*)p3)[i] = m_<%=name%>(((dtype*)p1)[i],((dtype*)p2)[i]);
+            if (p1 == p3) { // inplace case
+                for (i=0; i<n; i++) {
+                    check_intdivzero(*(dtype*)p2);
+                    ((dtype*)p1)[i] = m_<%=name%>(((dtype*)p1)[i],((dtype*)p2)[i]);
+                }
+            } else {
+                for (i=0; i<n; i++) {
+                    check_intdivzero(*(dtype*)p2);
+                    ((dtype*)p3)[i] = m_<%=name%>(((dtype*)p1)[i],((dtype*)p2)[i]);
+                }
             }
             return;
         }

--- a/ext/numo/narray/gen/tmpl/binary.c
+++ b/ext/numo/narray/gen/tmpl/binary.c
@@ -39,13 +39,46 @@ static void
             is_aligned_step(s2,sizeof(dtype)) &&
             is_aligned_step(s3,sizeof(dtype)) ) {
             //<% end %>
-            for (i=0; i<n; i++) {
+
+            if (s2 == 0){ // Broadcasting from scalar value.
                 check_intdivzero(*(dtype*)p2);
-                *(dtype*)p3 = m_<%=name%>(*(dtype*)p1,*(dtype*)p2);
-                p1 += s1;
-                p2 += s2;
-                p3 += s3;
+                if (s1 == sizeof(dtype) &&
+                    s3 == sizeof(dtype) ) {
+                    if (p1 == p3) { // inplace case
+                        for (i=0; i<n; i++) {
+                            ((dtype*)p1)[i] = m_<%=name%>(((dtype*)p1)[i],*(dtype*)p2);
+                        }
+                    } else {
+                        for (i=0; i<n; i++) {
+                            ((dtype*)p3)[i] = m_<%=name%>(((dtype*)p1)[i],*(dtype*)p2);
+                        }
+                    }
+                } else {
+                    for (i=0; i<n; i++) {
+                        *(dtype*)p3 = m_<%=name%>(*(dtype*)p1,*(dtype*)p2);
+                        p1 += s1;
+                        p3 += s3;
+                    }
+                }
+            } else { // Broadcasting from Numo::NArray
+                if (p1 == p3) { // inplace case
+                    for (i=0; i<n; i++) {
+                        check_intdivzero(*(dtype*)p2);
+                        *(dtype*)p1 = m_<%=name%>(*(dtype*)p1,*(dtype*)p2);
+                        p1 += s1;
+                        p2 += s2;
+                    }
+                } else {
+                    for (i=0; i<n; i++) {
+                        check_intdivzero(*(dtype*)p2);
+                        *(dtype*)p3 = m_<%=name%>(*(dtype*)p1,*(dtype*)p2);
+                        p1 += s1;
+                        p2 += s2;
+                        p3 += s3;
+                    }
+                }
             }
+
             return;
             //<% if need_align %>
         }


### PR DESCRIPTION
I wrote a patch to improve the performance of the broadcast.
(See #93 for details.)

## Benchmarked code
```
$ cat broadcast_fp32_0.rb
require 'benchmark'
require 'numo/narray'

num_iteration = 10000

Benchmark.bm 20 do |r|
  x = Numo::SFloat.ones([1000,784])
  y = Numo::SFloat.ones([1000,784])
  r.report "x.inplace + y" do
    num_iteration.times do
      x.inplace + y
    end
  end

  x = Numo::SFloat.ones([1000,784])
  y = Numo::SFloat.ones([1000,784])
  r.report "x.inplace + 1.0" do
    num_iteration.times do
      x.inplace + 1.0
    end
  end

  x = Numo::SFloat.ones([1000,784])
  z = Numo::SFloat.ones([1000,1])
  r.report "x.inplace + z" do
    num_iteration.times do
      x.inplace + z
    end
  end

  x = Numo::SFloat.ones([1000,784])
  y = Numo::SFloat.ones([1000,784])
  r.report "x.inplace - y" do
    num_iteration.times do
      x.inplace - y
    end
  end

  x = Numo::SFloat.ones([1000,784])
  y = Numo::SFloat.ones([1000,784])
  r.report "x.inplace - 1.0" do
    num_iteration.times do
      x.inplace - 1.0
    end
  end

  x = Numo::SFloat.ones([1000,784])
  z = Numo::SFloat.ones([1000,1])
  r.report "x.inplace - z" do
    num_iteration.times do
      x.inplace - z
    end
  end

  x = Numo::SFloat.ones([1000,784])
  y = Numo::SFloat.ones([1000,784])
  r.report "x.inplace * y" do
    num_iteration.times do
      x.inplace * y
    end
  end

  x = Numo::SFloat.ones([1000,784])
  y = Numo::SFloat.ones([1000,784])
  r.report "x.inplace * 1.0" do
    num_iteration.times do
      x.inplace * 1.0
    end
  end

  x = Numo::SFloat.ones([1000,784])
  z = Numo::SFloat.ones([1000,1])
  r.report "x.inplace * z" do
    num_iteration.times do
      x.inplace * z
    end
  end

  x = Numo::SFloat.ones([1000,784])
  y = Numo::SFloat.ones([1000,784])
  r.report "x.inplace / y" do
    num_iteration.times do
      x.inplace / y
    end
  end

  x = Numo::SFloat.ones([1000,784])
  y = Numo::SFloat.ones([1000,784])
  r.report "x.inplace / 1.0" do
    num_iteration.times do
      x.inplace / 1.0
    end
  end

  x = Numo::SFloat.ones([1000,784])
  z = Numo::SFloat.ones([1000,1])
  r.report "x.inplace / z" do
    num_iteration.times do
      x.inplace / z
    end
  end
end
```

## numo-narray (0.9.1.2)
```
$ ruby broadcast_fp32_0.rb
                           user     system      total        real
x.inplace + y          7.117035   0.014939   7.131974 (  7.136282)
x.inplace + 1.0        6.789272   0.024060   6.813332 (  6.827599)
x.inplace + z          7.175892   0.017552   7.193444 (  7.202093)
x.inplace - y          7.153403   0.018990   7.172393 (  7.179199)
x.inplace - 1.0        7.126394   0.035196   7.161590 (  7.165015)
x.inplace - z          7.661959   0.027423   7.689382 (  7.691847)
x.inplace * y          7.292331   0.019903   7.312234 (  7.313645)
x.inplace * 1.0        7.400105   0.027464   7.427569 (  7.456064)
x.inplace * z          7.615981   0.014080   7.630061 (  7.648254)
x.inplace / y         21.070260   0.040930  21.111190 ( 21.118321)
x.inplace / 1.0       20.598696   0.037721  20.636417 ( 20.666177)
x.inplace / z         20.315364   0.034728  20.350092 ( 20.356939)
```

## numo-narray (this pull request)
```
$ ruby broadcast_fp32_0.rb
                           user     system      total        real
x.inplace + y          7.155114   0.016712   7.171826 (  7.186810)
x.inplace + 1.0        3.459453   0.015183   3.474636 (  3.481500)
x.inplace + z          3.663317   0.010254   3.673571 (  3.680733)
x.inplace - y          6.845094   0.017954   6.863048 (  6.870259)
x.inplace - 1.0        3.560169   0.013040   3.573209 (  3.586768)
x.inplace - z          3.646052   0.005849   3.651901 (  3.660764)
x.inplace * y          7.467288   0.023760   7.491048 (  7.519944)
x.inplace * 1.0        3.894445   0.003156   3.897601 (  3.898232)
x.inplace * z          3.689050   0.006646   3.695696 (  3.699812)
x.inplace / y         20.479120   0.030151  20.509271 ( 20.584411)
x.inplace / 1.0        5.516712   0.005548   5.522260 (  5.536777)
x.inplace / z          5.517277   0.013617   5.530894 (  5.537079)
```

## Environment
* CentOS Linux release 7.3.1611 (Core)
* ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux]
