### PR TITLE
Require Ruby 2.2 or later

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,7 @@ namespace :build do
       ["git", "clone", "file://#{Dir.pwd}/.git", build_dir],
       ["cd", build_dir],
       ["bundle"],
-      ["rake", "cross", "native", "gem"],
+      ["rake", "RUBY_CC_VERSION=2.5.0:2.4.0:2.3.0", "cross", "native", "gem"],
     ]
     raw_commands = commands.collect do |command|
       Shellwords.join(command)

--- a/numo-narray.gemspec
+++ b/numo-narray.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{alpha release of Numo::NArray - New NArray class library in Ruby/Numo (NUmerical MOdule)}
   spec.homepage      = "https://github.com/ruby-numo/numo-narray"
   spec.license       = "BSD-3-Clause"
-  spec.required_ruby_version = '~> 2.1'
+  spec.required_ruby_version = '=> 2.2'
 
   spec.files         = `git ls-files Gemfile README.md Rakefile lib ext numo-narray.gemspec spec`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Because rb_get_kwargs() is available since Ruby 2.2.

See also for `required_ruby_version=`: https://guides.rubygems.org/specification-reference/#required_ruby_version=