### PR TITLE
Require Ruby 2.1 or later

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,13 @@ namespace :build do
       ["git", "clone", "file://#{Dir.pwd}/.git", build_dir],
       ["cd", build_dir],
       ["bundle"],
-      ["rake", "cross", "native", "gem"],
+      [
+        "rake",
+        "RUBY_CC_VERSION=2.5.0:2.4.0:2.3.0:2.2.2:2.1.6",
+        "cross",
+        "native",
+        "gem",
+      ],
     ]
     raw_commands = commands.collect do |command|
       Shellwords.join(command)

--- a/ext/numo/narray/extconf.rb
+++ b/ext/numo/narray/extconf.rb
@@ -2,8 +2,8 @@ require 'rbconfig.rb'
 require 'mkmf'
 require "erb"
 
-if RUBY_VERSION < "2.0.0"
-  puts "Numo::NArray requires Ruby version 2.0 or later."
+if RUBY_VERSION < "2.1.0"
+  puts "Numo::NArray requires Ruby version 2.1 or later."
   exit(1)
 end
 


### PR DESCRIPTION
Because we specify "~> 2.1" in gemspec.

We may be able to drop 2.2 or older support in near future. Because
Ruby 2.2 was EOL at 2018-03.