### PR TITLE
Fixed "rake build:windows".

### DIFF
--- a/ext/numo/narray/depend.erb
+++ b/ext/numo/narray/depend.erb
@@ -13,14 +13,14 @@ TAGS : $(TAGSRC)
 doc :
 	yard doc *.c types/*.c
 
-C_TMPL = <%=Dir.glob("gen/tmpl*/*.c").join(" ")%>
+C_TMPL = <%=Dir.glob("#{__dir__}/gen/tmpl*/*.c").join(" ")%>
 
-COGEN = gen/cogen.rb
-DEPENDS = $(C_TMPL) gen/*.rb
+COGEN = <%= __dir__ %>/gen/cogen.rb
+DEPENDS = $(C_TMPL) <%= __dir__ %>/gen/*.rb
 
 <%
    type_c = []
-   type_rb = Dir.glob("gen/def/*.rb")
+   type_rb = Dir.glob("#{__dir__}/gen/def/*.rb")
    type_rb.each do |s|
      type_c << c = "types/"+File.basename(s,".rb")+".c"
 %>


### PR DESCRIPTION
Can't build current master by "rake build:windows".
I fixed this patch. (See #101 for details.)

```
$ git clone https://github.com/ruby-numo/numo-narray.git
$ cd numo-narray/
$ su

# systemctl start docker
# bundle exec rake build:windows
rm -rf tmp/windows
mkdir -p tmp/windows
rake-compiler-dock bash -c "git clone file:///home/naitoh/numo-narray/.git tmp/windows && cd tmp/windows && bundle && rake RUBY_CC_VERSION\\=2.5.0:2.4.0:2.3.0:2.2.2:2.1.6 cross native gem"
Cloning into 'tmp/windows'...
remote: Counting objects: 5320, done.
remote: Compressing objects: 100% (1245/1245), done.
remote: Total 5320 (delta 3315), reused 5320 (delta 3315)
Receiving objects: 100% (5320/5320), 1.24 MiB | 6.81 MiB/s, done.
Resolving deltas: 100% (3315/3315), done.
Don't run Bundler as root. Bundler can ask for sudo if it is needed, and
installing your bundle as root will break this application for all non-root
users on this machine.
Fetching gem metadata from https://rubygems.org/.............
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Fetching rake 0.9.6
Installing rake 0.9.6
Using bundler 1.16.1
Using numo-narray 0.9.1.2 from source at `.`
Fetching power_assert 1.1.2
Installing power_assert 1.1.2
Using rake-compiler 1.0.4
Fetching rake-compiler-dock 0.6.3
Installing rake-compiler-dock 0.6.3
Fetching test-unit 3.2.8
Installing test-unit 3.2.8
Bundle complete! 6 Gemfile dependencies, 7 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
mkdir -p lib/2.5/numo
mkdir -p tmp/x86-mingw32/numo/narray/2.5.0/numo
cd tmp/x86-mingw32/numo/narray/2.5.0
/usr/local/rvm/rubies/ruby-2.5.0/bin/ruby -I. ../../../../../ext/numo/narray/extconf.rb
checking for stdbool.h... yes
checking for stdint.h... yes
checking for bool in stdbool.h... yes
checking for u_int8_t in stdint.h... no
checking for uint8_t in stdint.h... yes
checking for u_int16_t in stdint.h... no
checking for uint16_t in stdint.h... yes
checking for int32_t in stdint.h... yes
checking for u_int32_t in stdint.h... no
checking for uint32_t in stdint.h... yes
checking for int64_t in stdint.h... yes
checking for u_int64_t in stdint.h... no
checking for uint64_t in stdint.h... yes
checking for exp10()... no
checking for rb_cComplex... yes
creating numo/extconf.h
creating Makefile
cd -
cd tmp/x86-mingw32/numo/narray/2.5.0
/usr/bin/make
compiling ../../../../../ext/numo/narray/narray.c
compiling ../../../../../ext/numo/narray/array.c
compiling ../../../../../ext/numo/narray/step.c
compiling ../../../../../ext/numo/narray/index.c
compiling ../../../../../ext/numo/narray/ndloop.c
compiling ../../../../../ext/numo/narray/data.c
compiling ../../../../../ext/numo/narray/math.c
compiling ../../../../../ext/numo/narray/SFMT.c
compiling ../../../../../ext/numo/narray/struct.c
compiling ../../../../../ext/numo/narray/rand.c
linking shared-object numo/narray.so
i686-w64-mingw32-gcc: error: types/bit.o: No such file or directory
i686-w64-mingw32-gcc: error: types/int8.o: No such file or directory
i686-w64-mingw32-gcc: error: types/int16.o: No such file or directory
i686-w64-mingw32-gcc: error: types/int32.o: No such file or directory
i686-w64-mingw32-gcc: error: types/int64.o: No such file or directory
i686-w64-mingw32-gcc: error: types/uint8.o: No such file or directory
i686-w64-mingw32-gcc: error: types/uint16.o: No such file or directory
i686-w64-mingw32-gcc: error: types/uint32.o: No such file or directory
i686-w64-mingw32-gcc: error: types/uint64.o: No such file or directory
i686-w64-mingw32-gcc: error: types/sfloat.o: No such file or directory
i686-w64-mingw32-gcc: error: types/dfloat.o: No such file or directory
i686-w64-mingw32-gcc: error: types/scomplex.o: No such file or directory
i686-w64-mingw32-gcc: error: types/dcomplex.o: No such file or directory
i686-w64-mingw32-gcc: error: types/robject.o: No such file or directory
Makefile:263: recipe for target 'narray.so' failed
make: *** [narray.so] Error 1
rake aborted!
Command failed with status (2): [/usr/bin/make...]
/usr/local/rvm/gems/ruby-2.5.0/gems/rake-compiler-1.0.4/lib/rake/extensiontask.rb:166:in `block (2 levels) in define_compile_tasks'
/usr/local/rvm/gems/ruby-2.5.0/gems/rake-compiler-1.0.4/lib/rake/extensiontask.rb:165:in `block in define_compile_tasks'
/usr/local/rvm/gems/ruby-2.5.0/bin/ruby_executable_hooks:15:in `eval'
/usr/local/rvm/gems/ruby-2.5.0/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => native => native:x86-mingw32 => native:numo-narray:x86-mingw32 => tmp/x86-mingw32/stage/lib/2.5/numo/narray.so => copy:numo/narray:x86-mingw32:2.5.0 => tmp/x86-mingw32/numo/narray/2.5.0/numo/narray.so
(See full trace by running task with --trace)
```

Best regard.