### PR TITLE
Performance improvement of add/sub/mul/div/sqrt by SIMD calculation (64bit OS only)

### DIFF
--- a/ext/numo/narray/extconf.rb
+++ b/ext/numo/narray/extconf.rb
@@ -12,9 +12,6 @@ rm_f 'numo/extconf.h'
 #$CFLAGS="-g3 -O0 -Wall"
 #$CFLAGS=" $(cflags) -O3 -m64 -msse2 -funroll-loops"
 #$CFLAGS=" $(cflags) -O3"
-if (::RbConfig::CONFIG['target_cpu'] == 'x86_64') or  (::RbConfig::CONFIG['target_cpu'] == 'x64')
-  $CFLAGS += " -msse2"
-end
 $INCFLAGS = "-Itypes #$INCFLAGS"
 
 $INSTALLFILES = Dir.glob(%w[numo/*.h numo/types/*.h]).map{|x| [x,'$(archdir)'] }

--- a/ext/numo/narray/extconf.rb
+++ b/ext/numo/narray/extconf.rb
@@ -12,6 +12,9 @@ rm_f 'numo/extconf.h'
 #$CFLAGS="-g3 -O0 -Wall"
 #$CFLAGS=" $(cflags) -O3 -m64 -msse2 -funroll-loops"
 #$CFLAGS=" $(cflags) -O3"
+if (::RbConfig::CONFIG['target_cpu'] == 'x86_64') or  (::RbConfig::CONFIG['target_cpu'] == 'x64')
+  $CFLAGS += " -msse2"
+end
 $INCFLAGS = "-Itypes #$INCFLAGS"
 
 $INSTALLFILES = Dir.glob(%w[numo/*.h numo/types/*.h]).map{|x| [x,'$(archdir)'] }

--- a/ext/numo/narray/gen/cogen.rb
+++ b/ext/numo/narray/gen/cogen.rb
@@ -1,5 +1,12 @@
 #! /usr/bin/env ruby
 
+# Build gems for Windows by using fake RbConfig::CONFIG by rake-compiler.
+fake_path  = File.join(Dir.pwd, 'fake.rb')
+if File.exist? fake_path
+  $:.unshift(Dir.pwd)
+  require 'fake'
+end
+
 thisdir = File.dirname(__FILE__)
 libpath = File.absolute_path(File.dirname(__FILE__))+"/../../../../lib"
 $LOAD_PATH.unshift libpath

--- a/ext/numo/narray/gen/cogen.rb
+++ b/ext/numo/narray/gen/cogen.rb
@@ -43,6 +43,12 @@ code = DefLib.new do
   set file_name: $output||""
   set include_files: ["numo/types/#{type_name}.h"]
   set lib_name: "numo_"+type_name
+  
+  if (::RbConfig::CONFIG['target_cpu'] == 'x86_64') or  (::RbConfig::CONFIG['target_cpu'] == 'x64')
+    set is_simd: true
+  else
+    set is_simd: false
+  end
 
   def_class do
     extend NArrayMethod

--- a/ext/numo/narray/gen/def/dfloat.rb
+++ b/ext/numo/narray/gen/def/dfloat.rb
@@ -5,6 +5,7 @@ set class_name:          "DFloat"
 set class_alias:         "Float64"
 set class_var:           "cT"
 set ctype:               "double"
+set simd_type:           "pd"
 
 set has_math:            true
 set is_bit:              false

--- a/ext/numo/narray/gen/def/sfloat.rb
+++ b/ext/numo/narray/gen/def/sfloat.rb
@@ -5,6 +5,7 @@ set class_name:          "SFloat"
 set class_alias:         "Float32"
 set class_var:           "cT"
 set ctype:               "float"
+set simd_type:           "ps"
 
 set has_math:            true
 set is_bit:              false

--- a/ext/numo/narray/gen/spec.rb
+++ b/ext/numo/narray/gen/spec.rb
@@ -364,6 +364,8 @@ if has_math
 fn = get(:full_class_name)
 cn = get(:class_name)
 nm = get(:name)
+st = get(:simd_type)
+dp = get(:is_double_precision)
 is_c = is_complex
 
 def_module do
@@ -374,6 +376,9 @@ def_module do
   set full_module_name: fn+"::NMath"
   set module_name: "Math"
   set module_var: "mTM"
+  set simd_type: st
+  set is_double_precision: dp 
+  set is_complex: is_c
 
   math "sqrt"
   math "cbrt"

--- a/ext/numo/narray/gen/tmpl/binary.c
+++ b/ext/numo/narray/gen/tmpl/binary.c
@@ -16,23 +16,23 @@ static void
     char    *p1, *p2, *p3;
     ssize_t  s1, s2, s3;
 
+<% if is_simd and is_float and !is_complex and !is_object and %w[add sub mul div].include? name %>
+    size_t cnt;
+    size_t cnt_simd_loop = -1;
+  <% if is_double_precision %>
+    __m128d a;
+    __m128d b;
+  <% else %>
+    __m128 a;
+    __m128 b;
+  <% end %>
+    size_t num_pack; // Number of elements packed for SIMD.
+    num_pack = SIMD_ALIGNMENT_SIZE / sizeof(dtype);
+<% end %>
     INIT_COUNTER(lp, n);
     INIT_PTR(lp, 0, p1, s1);
     INIT_PTR(lp, 1, p2, s2);
     INIT_PTR(lp, 2, p3, s3);
-<% if is_simd and is_float and !is_complex and !is_object and %w[add sub mul div].include? name %>
-    size_t num_pack = SIMD_ALIGNMENT_SIZE / sizeof(dtype); // Number of elements packed for SIMD.
-    size_t cnt, cnt_simd_loop;
-  <% if is_double_precision %>
-    __m128d a;
-    __m128d b;
-    __m128d c;
-  <% else %>
-    __m128 a;
-    __m128 b;
-    __m128 c;
-  <% end %>
-<% end %>
 
     //<% if need_align %>
     if (is_aligned(p1,sizeof(dtype)) &&
@@ -44,44 +44,55 @@ static void
             s3 == sizeof(dtype) ) {
 <% if is_simd and is_float and !is_complex and !is_object and %w[add sub mul div].include? name %>
             // Check number of elements. & Check same alignment.
-            if ((n < num_pack) || !is_same_aligned3(&((dtype*)p1)[i], &((dtype*)p2)[i], &((dtype*)p3)[i], SIMD_ALIGNMENT_SIZE)){
-<% end %>
-                if (p1 == p3) { // inplace case (for non-SIMD only.)
-                    for (i=0; i<n; i++) {
-                        check_intdivzero(((dtype*)p2)[i]);
+            if ((n >= num_pack) && is_same_aligned3(&((dtype*)p1)[i], &((dtype*)p2)[i], &((dtype*)p3)[i], SIMD_ALIGNMENT_SIZE)){
+                // Calculate up to the position just before the start of SIMD computation.
+                cnt = get_count_of_elements_not_aligned_to_simd_size(&((dtype*)p1)[i], SIMD_ALIGNMENT_SIZE, sizeof(dtype));
+                if (p1 == p3) { // inplace case
+                    for (; i < cnt; i++) {
                         ((dtype*)p1)[i] = m_<%=name%>(((dtype*)p1)[i],((dtype*)p2)[i]);
                     }
                 } else {
-                    for (i=0; i<n; i++) {
-                        check_intdivzero(((dtype*)p2)[i]);
+                    for (; i < cnt; i++) {
                         ((dtype*)p3)[i] = m_<%=name%>(((dtype*)p1)[i],((dtype*)p2)[i]);
                     }
-                }
-<% if is_simd and is_float and !is_complex and !is_object and %w[add sub mul div].include? name %>
-            } else {
-                // Calculate up to the position just before the start of SIMD computation.
-                cnt = get_count_of_elements_not_aligned_to_simd_size(&((dtype*)p1)[i], SIMD_ALIGNMENT_SIZE, sizeof(dtype));
-                for (; i < cnt; i++) {
-                    ((dtype*)p3)[i] = m_<%=name%>(((dtype*)p1)[i],((dtype*)p2)[i]);
                 }
 
                 // Get the count of SIMD computation loops.
                 cnt_simd_loop = (n - i) % num_pack;
 
                 // SIMD computation.
-                for(; i < n - cnt_simd_loop; i += num_pack){
-                    a = _mm_load_<%=simd_type%>(&((dtype*)p1)[i]);
-                    b = _mm_load_<%=simd_type%>(&((dtype*)p2)[i]);
-                    c = _mm_<%=name%>_<%=simd_type%>(a, b);
-                    _mm_store_<%=simd_type%>(&((dtype*)p3)[i], c);
+                if (p1 == p3) { // inplace case
+                    for(; i < n - cnt_simd_loop; i += num_pack){
+                        a = _mm_load_<%=simd_type%>(&((dtype*)p1)[i]);
+                        b = _mm_load_<%=simd_type%>(&((dtype*)p2)[i]);
+                        a = _mm_<%=name%>_<%=simd_type%>(a, b);
+                        _mm_store_<%=simd_type%>(&((dtype*)p1)[i], a);
+                    }
+                } else {
+                    for(; i < n - cnt_simd_loop; i += num_pack){
+                        a = _mm_load_<%=simd_type%>(&((dtype*)p1)[i]);
+                        b = _mm_load_<%=simd_type%>(&((dtype*)p2)[i]);
+                        a = _mm_<%=name%>_<%=simd_type%>(a, b);
+                        _mm_stream_<%=simd_type%>(&((dtype*)p3)[i], a);
+                    }
                 }
+            }
 
-                // Compute the remainder of the SIMD operation.
-                if (cnt_simd_loop != 0){
+            // Compute the remainder of the SIMD operation.
+            if (cnt_simd_loop != 0){
+<% end %>
+                if (p1 == p3) { // inplace case
                     for (; i<n; i++) {
+                        check_intdivzero(((dtype*)p2)[i]);
+                        ((dtype*)p1)[i] = m_<%=name%>(((dtype*)p1)[i],((dtype*)p2)[i]);
+                    }
+                } else {
+                    for (; i<n; i++) {
+                        check_intdivzero(((dtype*)p2)[i]);
                         ((dtype*)p3)[i] = m_<%=name%>(((dtype*)p1)[i],((dtype*)p2)[i]);
                     }
                 }
+<% if is_simd and is_float and !is_complex and !is_object and %w[add sub mul div].include? name %>
             }
 <% end %>
             return;
@@ -99,42 +110,53 @@ static void
 <% if is_simd and is_float and !is_complex and !is_object and %w[add sub mul div].include? name %>
                     // Broadcast a scalar value and use it for SIMD computation.
                     b = _mm_load1_<%=simd_type%>(&((dtype*)p2)[0]);
+
                     // Check number of elements. & Check same alignment.
-                    if ((n < num_pack) || !is_same_aligned2(&((dtype*)p1)[i], &((dtype*)p3)[i], SIMD_ALIGNMENT_SIZE)){
-<% end %>
-                        if (p1 == p3) { // inplace case (for non-SIMD only.)
-                            for (i=0; i<n; i++) {
+                    if ((n >= num_pack) && is_same_aligned2(&((dtype*)p1)[i], &((dtype*)p3)[i], SIMD_ALIGNMENT_SIZE)){
+                        // Calculate up to the position just before the start of SIMD computation.
+                        cnt = get_count_of_elements_not_aligned_to_simd_size(&((dtype*)p1)[i], SIMD_ALIGNMENT_SIZE, sizeof(dtype));
+                        if (p1 == p3) { // inplace case
+                            for (; i < cnt; i++) {
                                 ((dtype*)p1)[i] = m_<%=name%>(((dtype*)p1)[i],*(dtype*)p2);
                             }
                         } else {
-                            for (i=0; i<n; i++) {
+                            for (; i < cnt; i++) {
                                 ((dtype*)p3)[i] = m_<%=name%>(((dtype*)p1)[i],*(dtype*)p2);
                             }
-                        }
-<% if is_simd and is_float and !is_complex and !is_object and %w[add sub mul div].include? name %>
-                    } else {
-                        // Calculate up to the position just before the start of SIMD computation.
-                        cnt = get_count_of_elements_not_aligned_to_simd_size(&((dtype*)p1)[i], SIMD_ALIGNMENT_SIZE, sizeof(dtype));
-                        for (; i < cnt; i++) {
-                            ((dtype*)p3)[i] = m_<%=name%>(((dtype*)p1)[i],*(dtype*)p2);
                         }
 
                         // Get the count of SIMD computation loops.
                         cnt_simd_loop = (n - i) % num_pack;
 
                         // SIMD computation.
-                        for(; i < n - cnt_simd_loop; i += num_pack){
-                            a = _mm_load_<%=simd_type%>(&((dtype*)p1)[i]);
-                            c = _mm_<%=name%>_<%=simd_type%>(a, b);
-                            _mm_store_<%=simd_type%>(&((dtype*)p3)[i], c);
+                        if (p1 == p3) { // inplace case
+                            for(; i < n - cnt_simd_loop; i += num_pack){
+                                a = _mm_load_<%=simd_type%>(&((dtype*)p1)[i]);
+                                a = _mm_<%=name%>_<%=simd_type%>(a, b);
+                                _mm_store_<%=simd_type%>(&((dtype*)p1)[i], a);
+                            }
+                        } else {
+                            for(; i < n - cnt_simd_loop; i += num_pack){
+                                a = _mm_load_<%=simd_type%>(&((dtype*)p1)[i]);
+                                a = _mm_<%=name%>_<%=simd_type%>(a, b);
+                                _mm_stream_<%=simd_type%>(&((dtype*)p3)[i], a);
+                            }
                         }
+                    }
 
-                        // Compute the remainder of the SIMD operation.
-                        if (cnt_simd_loop != 0){
+                    // Compute the remainder of the SIMD operation.
+                    if (cnt_simd_loop != 0){
+<% end %>
+                        if (p1 == p3) { // inplace case
+                            for (; i<n; i++) {
+                                ((dtype*)p1)[i] = m_<%=name%>(((dtype*)p1)[i],*(dtype*)p2);
+                            }
+                        } else {
                             for (; i<n; i++) {
                                 ((dtype*)p3)[i] = m_<%=name%>(((dtype*)p1)[i],*(dtype*)p2);
                             }
                         }
+<% if is_simd and is_float and !is_complex and !is_object and %w[add sub mul div].include? name %>
                     }
 <% end %>
                 } else {

--- a/ext/numo/narray/gen/tmpl/lib.c
+++ b/ext/numo/narray/gen/tmpl/lib.c
@@ -14,6 +14,11 @@
 
 #define m_map(x) m_num_to_data(rb_yield(m_data_to_num(x)))
 
+<% if is_simd %>
+#include <emmintrin.h>
+#define SIMD_ALIGNMENT_SIZE 16
+<% end %>
+
 <% id_decl.each do |x| %>
 <%= x %>
 <% end %>

--- a/ext/numo/narray/numo/template.h
+++ b/ext/numo/narray/numo/template.h
@@ -145,5 +145,23 @@ is_aligned_step(const ssize_t step, const size_t alignment)
     return ((step) & ((alignment)-1)) == 0;
 }
 
+static inline int
+get_count_of_elements_not_aligned_to_simd_size(const void *ptr, const size_t alignment, const size_t element_size)
+{
+    int cnt = (size_t)(ptr) & ((alignment)-1);
+    return cnt == 0 ?  0 : (alignment - cnt) / element_size;
+}
+
+static inline int is_same_aligned2(const void *ptr1, const void *ptr2, const size_t alignment)
+{
+    return ((size_t)(ptr1) & ((alignment)-1)) == ((size_t)(ptr2) & ((alignment)-1));
+}
+
+static inline int is_same_aligned3(const void *ptr1, const void *ptr2, const void *ptr3, const size_t alignment)
+{
+    return (((size_t)(ptr1) & ((alignment)-1)) == ((size_t)(ptr2) & ((alignment)-1))) &&
+           (((size_t)(ptr1) & ((alignment)-1)) == ((size_t)(ptr3) & ((alignment)-1)));
+}
+
 
 #endif /* ifndef TEMPLATE_H */

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -240,5 +240,93 @@ class NArrayTest < Test::Unit::TestCase
         assert_raise(Numo::NArray::ShapeError) { a.dot(b) }
       end
     end
+
+    sub_test_case "#{dtype}, simd" do
+      test "no simd add" do
+        a = dtype[4..6]
+        b = dtype[1..3]
+        assert { a + b         == [5, 7, 9] }
+        assert { a.inplace + b == [5, 7, 9] }
+      end
+      test "no simd sub" do
+        a = dtype[4..6]
+        b = dtype[1..3]
+        assert { a - b         == [3, 3, 3] }
+        assert { a.inplace - b == [3, 3, 3] }
+      end
+      test "no simd mul" do
+        a = dtype[4..6]
+        b = dtype[1..3]
+        assert { a * b         == [4, 10, 18] }
+        assert { a.inplace * b == [4, 10, 18] }
+      end
+      test "no simd div" do
+        a = dtype[4..6]
+        b = dtype[1..3]
+        assert { a / b         == [4, 2.5, 2] }
+        assert { a.inplace / b == [4, 2.5, 2] }
+      end
+      test "no simd sqrt" do
+        a = dtype[4,9,16]
+        assert { Numo::NMath.sqrt(a)         == [2, 3, 4] }
+        assert { Numo::NMath.sqrt(a.inplace) == [2, 3, 4] }
+      end
+
+      test "simd add" do
+        a = dtype[11..19]
+        b = dtype.ones(9)
+        assert { a + b         == [12, 13, 14, 15, 16, 17, 18, 19, 20] }
+        assert { a.inplace + b == [12, 13, 14, 15, 16, 17, 18, 19, 20] }
+      end
+      test "simd sub" do
+        a = dtype[11..19]
+        b = dtype.ones(9)
+        assert { a - b         == [10, 11, 12, 13, 14, 15, 16, 17, 18] }
+        assert { a.inplace - b == [10, 11, 12, 13, 14, 15, 16, 17, 18] }
+      end
+      test "simd mul" do
+        a = dtype[11..19]
+        b = dtype.ones(9) * 2
+        assert { a * b         == [22, 24, 26, 28, 30, 32, 34, 36, 38] }
+        assert { a.inplace * b == [22, 24, 26, 28, 30, 32, 34, 36, 38] }
+      end
+      test "simd div" do
+        a = dtype[11..19]
+        b = dtype.ones(9) * 2
+        assert { a / b         == [5.5, 6, 6.5, 7, 7.5, 8, 8.5, 9, 9.5] }
+        assert { a.inplace / b == [5.5, 6, 6.5, 7, 7.5, 8, 8.5, 9, 9.5] }
+      end
+      test "simd sqrt" do
+        a = dtype[4,9,16,25,36,49,64,81,100]
+        assert { Numo::NMath.sqrt(a)         == [2, 3, 4, 5, 6, 7, 8, 9, 10] }
+        assert { Numo::NMath.sqrt(a.inplace) == [2, 3, 4, 5, 6, 7, 8, 9, 10] }
+      end
+
+      test "simd broadcast scalar add" do
+        a = dtype[1..9]
+        assert { a + 1         == [2, 3, 4, 5, 6, 7, 8, 9, 10] }
+        assert { a.inplace + 1 == [2, 3, 4, 5, 6, 7, 8, 9, 10] }
+      end
+
+      test "simd broadcast not scalar add" do
+        a = dtype[10..19].reshape(2,5)
+        b = dtype[10..14]
+        assert { a + b         == [[20, 22, 24, 26, 28], [25, 27, 29, 31, 33]] }
+        assert { a.inplace + b == [[20, 22, 24, 26, 28], [25, 27, 29, 31, 33]] }
+      end
+
+      test "simd view add" do
+        a = dtype[10..19][1..9]
+        b = dtype[10..19][1..9]
+        assert { a + b         == [22, 24, 26, 28, 30, 32, 34, 36, 38] }
+        assert { a.inplace + b == [22, 24, 26, 28, 30, 32, 34, 36, 38] }
+      end
+
+      test "simd view sqrt" do
+        a = dtype[1,4,9,16,25,36,49,64,81,100]
+        assert { Numo::NMath.sqrt(a[1..9])         == [2, 3, 4, 5, 6, 7, 8, 9, 10] }
+        assert { Numo::NMath.sqrt(a[1..9].inplace) == [2, 3, 4, 5, 6, 7, 8, 9, 10] }
+      end
+    end
   end
 end


### PR DESCRIPTION
I implemented SSE2 support on numo-narray.

* SSE2 support is add / sub / mul / div / sqrt operation of SFloat and DFloat.
* It performs 16 Byte (DFloat(8 Byte) * 2) or (SFloat(4 Byte) * 4) calculations.
* I wanted to omit checking the CPU, so I did SSE support only for 64 bit package.

## Benchmark procedure (use benchmark_driver.gem)

I have created the numo-narray gems package for confirmation.

0.9.6.0 : master (b624b047acf92e73026ea4b72210fdfb165c33ae)
0.9.7.5 : simd support build (this pull request)

```
$ gem install benchmark_driver
$ gem install numo-narray # (0.9.0.3(Windows), 0.9.1.2(Linux/Mac), 0.9.6.0, 0.9.7.5)
$ benchmark-driver simd_fp32_add_sum_mul_div.yaml -o markdown
$ benchmark-driver simd_fp32_sqrt.yaml -o markdown
```

## Benchmarked code

```
$ cat simd_fp32_add_sum_mul_div.yaml 
contexts:
  # (0.9.0.3(Windows), 0.9.1.2(Linux/Mac)
  - gems: { numo-narray: 0.9.1.2 }
    require: false
    prelude: require 'numo/narray'
  # master
  - gems: { numo-narray: 0.9.6.0 }
    require: false
    prelude: require 'numo/narray'
  # simd
  - gems: { numo-narray: 0.9.7.5 }
    require: false
    prelude: require 'numo/narray'

loop_count: 5000
prelude: |
  x = Numo::SFloat.ones([1000,784])
  y = Numo::SFloat.ones([1000,784])
  z = Numo::SFloat.ones([1000,1])

benchmark:
  '[1000,784]         + [1000,784]': x         + y
  '[1000,784].inplace + [1000,784]': x.inplace + y
  '[1000,784]         + [1000,1]  ': x         + z
  '[1000,784].inplace + [1000,1]  ': x.inplace + z
  '[1000,784]         + 1         ': x         + 1
  '[1000,784].inplace + 1         ': x.inplace + 1
  '[1000,784]         - [1000,784]': x         - y
  '[1000,784].inplace - [1000,784]': x.inplace - y
  '[1000,784]         - [1000,1]  ': x         - z
  '[1000,784].inplace - [1000,1]  ': x.inplace - z
  '[1000,784]         - 1         ': x         - 1
  '[1000,784].inplace - 1         ': x.inplace - 1
  '[1000,784]         * [1000,784]': x         * y
  '[1000,784].inplace * [1000,784]': x.inplace * y
  '[1000,784]         * [1000,1]  ': x         * z
  '[1000,784].inplace * [1000,1]  ': x.inplace * z
  '[1000,784]         * 1         ': x         * 1
  '[1000,784].inplace * 1         ': x.inplace * 1
  '[1000,784]         / [1000,784]': x         / y
  '[1000,784].inplace / [1000,784]': x.inplace / y
  '[1000,784]         / [1000,1]  ': x         / z
  '[1000,784].inplace / [1000,1]  ': x.inplace / z
  '[1000,784]         / 1         ': x         / 1
  '[1000,784].inplace / 1         ': x.inplace / 1
```

```
$ cat simd_fp32_sqrt.yaml
contexts:
  # (0.9.0.3(Windows), 0.9.1.2(Linux/Mac)
  - gems: { numo-narray: 0.9.1.2 }
    require: false
    prelude: require 'numo/narray'
  # master
  - gems: { numo-narray: 0.9.6.0 }
    require: false
    prelude: require 'numo/narray'
  # simd
  - gems: { numo-narray: 0.9.7.5 }
    require: false
    prelude: require 'numo/narray'

loop_count: 5000
prelude: |
  x = Numo::SFloat.ones([1000,784])
benchmark:
  'Numo::NMath.sqrt([1000,784])':           Numo::NMath.sqrt(x) 
  'Numo::NMath.sqrt([1000,784].inplace)':   Numo::NMath.sqrt(x.inplace) 
```


## CentOS 7.3 x86_64 ruby 2.5.1

* Iteration per second (i/s) : (The higher the value, the faster.)

|                                 |numo-narray 0.9.1.2|numo-narray 0.9.6.0|numo-narray 0.9.7.5|
|:--------------------------------|:-------|:-------|:-------|
|[1000,784]         + [1000,784]  |  1.171k|  1.203k|  1.651k|
|[1000,784].inplace + [1000,784]  |  1.677k|  1.809k|  1.834k|
|[1000,784]         + [1000,1]    |  1.281k|  1.549k|  2.567k|
|[1000,784].inplace + [1000,1]    |  1.462k|  3.098k|  4.736k|
|[1000,784]         + 1           |  1.338k|  1.795k|  3.527k|
|[1000,784].inplace + 1           |  1.565k|  3.292k|  5.154k|
|[1000,784]         - [1000,784]  |  1.182k|  1.171k|  1.601k|
|[1000,784].inplace - [1000,784]  |  1.549k|  1.943k|  2.032k|
|[1000,784]         - [1000,1]    |  1.133k|  1.614k|  2.680k|
|[1000,784].inplace - [1000,1]    |  1.365k|  2.880k|  4.486k|
|[1000,784]         - 1           |  1.318k|  1.774k|  3.448k|
|[1000,784].inplace - 1           |  1.559k|  3.265k|  4.915k|
|[1000,784]         * [1000,784]  |  1.196k|  1.181k|  1.671k|
|[1000,784].inplace * [1000,784]  |  1.558k|  1.963k|  1.950k|
|[1000,784]         * [1000,1]    |  1.159k|  1.608k|  2.646k|
|[1000,784].inplace * [1000,1]    |  1.441k|  3.160k|  4.871k|
|[1000,784]         * 1           |  1.294k|  1.779k|  3.479k|
|[1000,784].inplace * 1           |  1.444k|  3.325k|  5.149k|
|[1000,784]         / [1000,784]  |  1.171k|  1.150k|  1.555k|
|[1000,784].inplace / [1000,784]  | 539.643|  1.701k|  1.903k|
|[1000,784]         / [1000,1]    | 512.975|  1.562k|  1.743k|
|[1000,784].inplace / [1000,1]    | 549.890|  2.111k|  2.123k|
|[1000,784]         / 1           | 532.381|  1.631k|  2.056k|
|[1000,784].inplace / 1           | 553.213|  2.127k|  2.131k|

* not inplace case : It is up to x2 faster.
* inplace case : It is up to x1.5 faster.

|                                     |numo-narray 0.9.1.2|numo-narray 0.9.6.0|numo-narray 0.9.7.5|
|:------------------------------------|:-------|:-------|:-------|
|Numo::NMath.sqrt([1000,784])         | 355.587| 364.303|  1.728k|
|Numo::NMath.sqrt([1000,784].inplace) | 382.418| 383.384|  2.101k|

* sqrt case : It is up to x5.5 faster.

## macOS Sierra x86_64 ruby 2.5.1

|                                 |numo-narray 0.9.1.2|numo-narray 0.9.6.0|numo-narray 0.9.7.5|
|:--------------------------------|:-------|:-------|:-------|
|[1000,784]         + [1000,784]  |  572.911|  579.679|  678.012|
|[1000,784].inplace + [1000,784]  |   1.733k|   2.084k|   1.978k|
|[1000,784]         + [1000,1]    |  674.226|  697.059|  897.062|
|[1000,784].inplace + [1000,1]    |   1.980k|   5.126k|   5.183k|
|[1000,784]         + 1           |  667.842|  690.480|  868.792|
|[1000,784].inplace + 1           |   1.923k|   5.884k|   5.620k|
|[1000,784]         - [1000,784]  |  582.449|  573.143|  649.472|
|[1000,784].inplace - [1000,784]  |   1.695k|   1.937k|   1.936k|
|[1000,784]         - [1000,1]    |  672.634|  691.308|  894.606|
|[1000,784].inplace - [1000,1]    |   1.850k|   5.355k|   4.972k|
|[1000,784]         - 1           |  665.970|  686.283|  898.855|
|[1000,784].inplace - 1           |   1.842k|   5.078k|   5.112k|
|[1000,784]         * [1000,784]  |  602.026|  569.739|  625.532|
|[1000,784].inplace * [1000,784]  |   1.671k|   2.105k|   1.986k|
|[1000,784]         * [1000,1]    |  671.948|  696.801|  904.203|
|[1000,784].inplace * [1000,1]    |   1.680k|   4.947k|   4.774k|
|[1000,784]         * 1           |  665.831|  694.866|  889.393|
|[1000,784].inplace * 1           |   1.729k|   5.966k|   5.249k|
|[1000,784]         / [1000,784]  |  592.243|  580.529|  667.407|
|[1000,784].inplace / [1000,784]  |  537.486|   1.863k|   1.782k|
|[1000,784]         / [1000,1]    |  366.356|  704.211|  765.797|
|[1000,784].inplace / [1000,1]    |  533.741|   2.049k|   2.032k|
|[1000,784]         / 1           |  370.940|  699.323|  763.226|
|[1000,784].inplace / 1           |  531.773|   2.131k|   2.053k|

* not inplace case : It is up to x1.3 faster.
* inplace case : same speed. (Because it is automatically converted to vector (SSE) by Mac's compiler (CLang).)

|                                     |numo-narray 0.9.1.2|numo-narray 0.9.6.0|numo-narray 0.9.7.5|
|:------------------------------------|:-------|:-------|:-------|
|Numo::NMath.sqrt([1000,784])         |  365.772|  363.453|  780.978|
|Numo::NMath.sqrt([1000,784].inplace) |  523.718|  533.900|   2.122k|

* sqrt case : It is up to x4 faster.

## Windows 10 64bit Microsoft Windows [Version 10.0.17134.1] Ruby 2.4.4

|                                 |numo-narray 0.9.0.3|numo-narray 0.9.6.0|numo-narray 0.9.7.5|
|:--------------------------------|:-------|:-------|:-------|
|[1000,784]         + [1000,784]  |  423.975|  422.737|  489.319|
|[1000,784].inplace + [1000,784]  |   1.216k|   1.467k|   1.832k|
|[1000,784]         + [1000,1]    |  488.574|  512.015|  631.634|
|[1000,784].inplace + [1000,1]    |   1.404k|   2.040k|   4.642k|
|[1000,784]         + 1           |  488.238|  489.128|  609.528|
|[1000,784].inplace + 1           |   1.444k|   2.427k|   5.106k|
|[1000,784]         - [1000,784]  |  445.259|  452.173|  531.289|
|[1000,784].inplace - [1000,784]  |   1.235k|   1.513k|   1.793k|
|[1000,784]         - [1000,1]    |  473.921|  507.082|  633.342|
|[1000,784].inplace - [1000,1]    |   1.409k|   2.229k|   4.451k|
|[1000,784]         - 1           |  439.207|  483.447|  629.162|
|[1000,784].inplace - 1           |   1.487k|   2.309k|   4.739k|
|[1000,784]         * [1000,784]  |  405.144|  442.723|  511.312|
|[1000,784].inplace * [1000,784]  |   1.254k|   1.513k|   1.769k|
|[1000,784]         * [1000,1]    |  421.175|  457.227|  628.850|
|[1000,784].inplace * [1000,1]    |   1.399k|   2.167k|   4.633k|
|[1000,784]         * 1           |  486.041|  500.576|  636.908|
|[1000,784].inplace * 1           |   1.441k|   2.273k|   5.193k|
|[1000,784]         / [1000,784]  |  303.281|  298.255|  507.035|
|[1000,784].inplace / [1000,784]  |  511.030|  517.014|   1.658k|
|[1000,784]         / [1000,1]    |  308.295|  319.152|  554.125|
|[1000,784].inplace / [1000,1]    |  498.347|  541.467|   2.078k|
|[1000,784]         / 1           |  308.253|  304.664|  576.858|
|[1000,784].inplace / 1           |  535.286|  542.667|   2.089k|

* not inplace case : It is up to x1.9 faster.
* inplace case : It is up to x3.85 faster.

|                                      |numo-narray 0.9.0.3|numo-narray 0.9.6.0|numo-narray 0.9.7.5|
|:-------------------------------------|:-------|:-------|:-------|
|Numo::NMath.sqrt([1000,784])          |  245.211|  251.684|  556.241|
|Numo::NMath.sqrt([1000,784].inplace)  |  379.386|  380.740|   2.073k|

* sqrt case : It is up to x5.5 faster.