### PR TITLE
Fix bug in the triu_indices method that the k argument is ignored

### DIFF
--- a/lib/numo/narray/extra.rb
+++ b/lib/numo/narray/extra.rb
@@ -1036,7 +1036,7 @@ module Numo
         raise NArray::ShapeError, "must be >= 2-dimensional array"
       end
       m,n = shape[-2..-1]
-      NArray.triu_indices(m,n,k=0)
+      NArray.triu_indices(m,n,k)
     end
 
     # Return the indices for the uppler-triangle on and above the k-th diagonal.

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -148,6 +148,8 @@ class NArrayTest < Test::Unit::TestCase
         assert { a.reshape(nil,2) == [[1,2],[3,5],[7,11]] }
         assert { a.transpose == [[1,5],[2,7],[3,11]] }
         assert { a.transpose(1,0) == [[1,5],[2,7],[3,11]] }
+        assert { a.triu == [[1,2,3],[0,7,11]] }
+        assert { a.tril == [[1,0,0],[5,7,0]] }
 
         assert { a.sum == 29 }
         assert { a.sum(0) == [6, 9, 14] }


### PR DESCRIPTION
I found that the `k` argument of the `triu_indices` does not enable. As a result, the matrix returned by the `tril` method has zeros along diagonal elements. It is not a [lower triangular matrix](http://mathworld.wolfram.com/LowerTriangularMatrix.html).

```ruby
> require ‘numo/narray’
=> true
> a=Numo::DFloat.new(3,3).rand
=> Numo::DFloat#shape=[3,3]
[[0.0617545, 0.373067, 0.794815],
 [0.201042, 0.116041, 0.344032],
 [0.539948, 0.737815, 0.165089]]

> a.tril
=> Numo::DFloat#shape=[3,3]
[[0, 0, 0],
 [0.201042, 0, 0],
 [0.539948, 0.737815, 0]]

> a.triu_indices
=> Numo::Int32#shape=[6]
[0, 1, 2, 4, 5, 8]
> a.triu_indices(1)
=> Numo::Int32#shape=[6]
[0, 1, 2, 4, 5, 8]
> a.triu_indices(-1)
=> Numo::Int32#shape=[6]
[0, 1, 2, 4, 5, 8]
```

The cause of this bug is that the `k` argument of the `NArray.triu_indices` method is always given zero. This pull-request fixes that:

```ruby
> a.tril
=> Numo::DFloat#shape=[3,3]
[[0.0617545, 0, 0],
 [0.201042, 0.116041, 0],
 [0.539948, 0.737815, 0.165089]]

> a.triu_indices
=> Numo::Int32#shape=[6]
[0, 1, 2, 4, 5, 8]
> a.triu_indices(1)
=> Numo::Int32#shape=[3]
[1, 2, 5]
> a.triu_indices(-1)
=> Numo::Int32#shape=[8]
[0, 1, 2, 3, 4, 5, 7, 8]
```