### PR TITLE
[CI] Add rake test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,5 @@ before_install:
 script:
   - gem build numo-narray.gemspec
   - gem install numo-narray-*.gem
+  - bundle install
+  - rake test

--- a/Rakefile
+++ b/Rakefile
@@ -68,6 +68,9 @@ namespace :release do
   end
 end
 
+rescue LoadError
+end
+
 require 'rake/testtask'
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
@@ -76,5 +79,3 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/**/*_test.rb']
 end
 
-rescue LoadError
-end

--- a/numo-narray.gemspec
+++ b/numo-narray.gemspec
@@ -29,7 +29,11 @@ Gem::Specification.new do |spec|
   spec.extensions    = ["ext/numo/narray/extconf.rb"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake", "~> 0"
+  if RUBY_VERSION <'2.2' # Ruby 2.1.x
+    spec.add_development_dependency "rake", "<= 10.5", ">=10.1.1"
+  else
+    spec.add_development_dependency "rake"
+  end
   spec.add_development_dependency "test-unit"
   spec.add_development_dependency 'rake-compiler', "~> 1.0", ">= 1.0.1"
   spec.add_development_dependency "rake-compiler-dock", "~> 0"


### PR DESCRIPTION
This PR enables you to run test-unit on travis-ci.
Ruby 2.1 specifies the version of rake to work properly.