### PR TITLE
[WIP] Arithmetic sequence support.

### DIFF
--- a/ToDo
+++ b/ToDo
@@ -52,8 +52,6 @@
 
 * write barrier?
 
-* delete Numo::Step class.
-
 * move "reduce" field from RNArray to RNArrayView?
 
 * unify RNArrayBase and RNArrayView structure??

--- a/ext/numo/narray/array.c
+++ b/ext/numo/narray/array.c
@@ -128,12 +128,10 @@ VALUE rb_cArithSeq = rb_path2class("Enumerator::ArithmeticSequence");
         MDAI_ATTR_TYPE(type,v,end);
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
     } else if (rb_obj_is_kind_of(v, rb_cArithSeq)) {
-#else
-    } else if (rb_obj_is_kind_of(v, na_cStep)) {
-#endif
         MDAI_ATTR_TYPE(type,v,begin);
         MDAI_ATTR_TYPE(type,v,end);
         MDAI_ATTR_TYPE(type,v,step);
+#endif
     } else {
         type = na_object_type(type,v);
     }
@@ -224,7 +222,7 @@ na_mdai_investigate(na_mdai_t *mdai, int ndim)
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
         if (rb_obj_is_kind_of(v, rb_cRange) || rb_obj_is_kind_of(v, rb_cArithSeq)) {
 #else
-        if (rb_obj_is_kind_of(v, rb_cRange) || rb_obj_is_kind_of(v, na_cStep)) {
+        if (rb_obj_is_kind_of(v, rb_cRange) || rb_obj_is_kind_of(v, rb_cEnumerator)) {
 #endif
             nary_step_sequence(v,&length,&dbeg,&dstep);
             len += length-1;

--- a/ext/numo/narray/array.c
+++ b/ext/numo/narray/array.c
@@ -119,10 +119,18 @@ static VALUE
 
 static int na_mdai_object_type(int type, VALUE v)
 {
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+VALUE rb_cArithSeq = rb_path2class("Enumerator::ArithmeticSequence");
+#endif
+
     if (rb_obj_is_kind_of(v, rb_cRange)) {
         MDAI_ATTR_TYPE(type,v,begin);
         MDAI_ATTR_TYPE(type,v,end);
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+    } else if (rb_obj_is_kind_of(v, rb_cArithSeq)) {
+#else
     } else if (rb_obj_is_kind_of(v, na_cStep)) {
+#endif
         MDAI_ATTR_TYPE(type,v,begin);
         MDAI_ATTR_TYPE(type,v,end);
         MDAI_ATTR_TYPE(type,v,step);
@@ -187,6 +195,9 @@ na_mdai_investigate(na_mdai_t *mdai, int ndim)
     double dbeg, dstep;
     VALUE  v;
     VALUE  val;
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+    VALUE rb_cArithSeq = rb_path2class("Enumerator::ArithmeticSequence");
+#endif
 
     val = mdai->item[ndim-1].val;
     len = RARRAY_LEN(val);
@@ -210,7 +221,11 @@ na_mdai_investigate(na_mdai_t *mdai, int ndim)
             }
         }
         else
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+        if (rb_obj_is_kind_of(v, rb_cRange) || rb_obj_is_kind_of(v, rb_cArithSeq)) {
+#else
         if (rb_obj_is_kind_of(v, rb_cRange) || rb_obj_is_kind_of(v, na_cStep)) {
+#endif
             nary_step_sequence(v,&length,&dbeg,&dstep);
             len += length-1;
             mdai->type = na_mdai_object_type(mdai->type, v);

--- a/ext/numo/narray/array.c
+++ b/ext/numo/narray/array.c
@@ -119,10 +119,6 @@ static VALUE
 
 static int na_mdai_object_type(int type, VALUE v)
 {
-#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
-VALUE rb_cArithSeq = rb_path2class("Enumerator::ArithmeticSequence");
-#endif
-
     if (rb_obj_is_kind_of(v, rb_cRange)) {
         MDAI_ATTR_TYPE(type,v,begin);
         MDAI_ATTR_TYPE(type,v,end);
@@ -193,9 +189,6 @@ na_mdai_investigate(na_mdai_t *mdai, int ndim)
     double dbeg, dstep;
     VALUE  v;
     VALUE  val;
-#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
-    VALUE rb_cArithSeq = rb_path2class("Enumerator::ArithmeticSequence");
-#endif
 
     val = mdai->item[ndim-1].val;
     len = RARRAY_LEN(val);

--- a/ext/numo/narray/extconf.rb
+++ b/ext/numo/narray/extconf.rb
@@ -83,6 +83,7 @@ unless have_type("u_int64_t", stdint)
   have_type("uint64_t", stdint)
 end
 have_func("exp10")
+have_func("rb_arithmetic_sequence_extract")
 
 have_var("rb_cComplex")
 

--- a/ext/numo/narray/gen/tmpl/store_array.c
+++ b/ext/numo/narray/gen/tmpl/store_array.c
@@ -11,6 +11,9 @@ static void
     dtype  z;
     size_t len, c;
     double beg, step;
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+    VALUE rb_cArithSeq = rb_path2class("Enumerator::ArithmeticSequence");
+#endif
 
     INIT_COUNTER(lp, n);
     INIT_PTR_IDX(lp, 0, p1, s1, idx1);
@@ -47,7 +50,11 @@ static void
     if (idx1) {
         for (i=i1=0; i1<n1 && i<n; i++,i1++) {
             x = ptr[i1];
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
+#else
             if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, na_cStep)) {
+#endif
                 nary_step_sequence(x,&len,&beg,&step);
                 for (c=0; c<len && i<n; c++,i++) {
                     y = beg + step * c;
@@ -63,7 +70,11 @@ static void
     } else {
         for (i=i1=0; i1<n1 && i<n; i++,i1++) {
             x = ptr[i1];
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
+#else
             if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, na_cStep)) {
+#endif
                 nary_step_sequence(x,&len,&beg,&step);
                 for (c=0; c<len && i<n; c++,i++) {
                     y = beg + step * c;

--- a/ext/numo/narray/gen/tmpl/store_array.c
+++ b/ext/numo/narray/gen/tmpl/store_array.c
@@ -53,7 +53,7 @@ static void
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
             if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
 #else
-            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, na_cStep)) {
+            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cEnumerator)) {
 #endif
                 nary_step_sequence(x,&len,&beg,&step);
                 for (c=0; c<len && i<n; c++,i++) {
@@ -73,7 +73,7 @@ static void
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
             if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
 #else
-            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, na_cStep)) {
+            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cEnumerator)) {
 #endif
                 nary_step_sequence(x,&len,&beg,&step);
                 for (c=0; c<len && i<n; c++,i++) {

--- a/ext/numo/narray/gen/tmpl/store_array.c
+++ b/ext/numo/narray/gen/tmpl/store_array.c
@@ -11,9 +11,6 @@ static void
     dtype  z;
     size_t len, c;
     double beg, step;
-#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
-    VALUE rb_cArithSeq = rb_path2class("Enumerator::ArithmeticSequence");
-#endif
 
     INIT_COUNTER(lp, n);
     INIT_PTR_IDX(lp, 0, p1, s1, idx1);

--- a/ext/numo/narray/gen/tmpl_bit/store_array.c
+++ b/ext/numo/narray/gen/tmpl_bit/store_array.c
@@ -12,6 +12,9 @@ static void
     BIT_DIGIT z;
     size_t len, c;
     double beg, step;
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+    VALUE rb_cArithSeq = rb_path2class("Enumerator::ArithmeticSequence");
+#endif
 
     INIT_COUNTER(lp, n);
     INIT_PTR_BIT_IDX(lp, 0, a1, p1, s1, idx1);
@@ -48,7 +51,11 @@ static void
     if (idx1) {
         for (i=i1=0; i1<n1 && i<n; i++,i1++) {
             x = ptr[i1];
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
+#else
             if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, na_cStep)) {
+#endif
                 nary_step_sequence(x,&len,&beg,&step);
                 for (c=0; c<len && i<n; c++,i++) {
                     y = beg + step * c;
@@ -65,7 +72,11 @@ static void
     } else {
         for (i=i1=0; i1<n1 && i<n; i++,i1++) {
             x = ptr[i1];
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
+#else
             if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, na_cStep)) {
+#endif
                 nary_step_sequence(x,&len,&beg,&step);
                 for (c=0; c<len && i<n; c++,i++) {
                     y = beg + step * c;

--- a/ext/numo/narray/gen/tmpl_bit/store_array.c
+++ b/ext/numo/narray/gen/tmpl_bit/store_array.c
@@ -12,9 +12,6 @@ static void
     BIT_DIGIT z;
     size_t len, c;
     double beg, step;
-#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
-    VALUE rb_cArithSeq = rb_path2class("Enumerator::ArithmeticSequence");
-#endif
 
     INIT_COUNTER(lp, n);
     INIT_PTR_BIT_IDX(lp, 0, a1, p1, s1, idx1);

--- a/ext/numo/narray/gen/tmpl_bit/store_array.c
+++ b/ext/numo/narray/gen/tmpl_bit/store_array.c
@@ -54,7 +54,7 @@ static void
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
             if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
 #else
-            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, na_cStep)) {
+            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cEnumerator)) {
 #endif
                 nary_step_sequence(x,&len,&beg,&step);
                 for (c=0; c<len && i<n; c++,i++) {
@@ -75,7 +75,7 @@ static void
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
             if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
 #else
-            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, na_cStep)) {
+            if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cEnumerator)) {
 #endif
                 nary_step_sequence(x,&len,&beg,&step);
                 for (c=0; c<len && i<n; c++,i++) {

--- a/ext/numo/narray/index.c
+++ b/ext/numo/narray/index.c
@@ -277,9 +277,6 @@ na_parse_enumerator(VALUE enum_obj, int orig_dim, ssize_t size, na_index_arg_t *
 static void
 na_index_parse_each(volatile VALUE a, ssize_t size, int i, na_index_arg_t *q)
 {
-#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
-    VALUE rb_cArithSeq = rb_path2class("Enumerator::ArithmeticSequence");
-#endif
     switch(TYPE(a)) {
 
     case T_FIXNUM:

--- a/ext/numo/narray/index.c
+++ b/ext/numo/narray/index.c
@@ -16,24 +16,6 @@
 #define cIndex numo_cInt32
 #endif
 
-// from ruby/enumerator.c
-struct enumerator {
-    VALUE obj;
-    ID    meth;
-    VALUE args;
-    // use only above in this source
-    VALUE fib;
-    VALUE dst;
-    VALUE lookahead;
-    VALUE feedvalue;
-    VALUE stop_exc;
-    VALUE size;
-    // incompatible below depending on ruby version
-    //VALUE procs;                      // ruby 2.4
-    //rb_enumerator_size_func *size_fn; // ruby 2.1-2.4
-    //VALUE (*size_fn)(ANYARGS);        // ruby 2.0
-};
-
 // note: the memory refed by this pointer is not freed and causes memroy leak.
 typedef struct {
     size_t  n; // the number of elements of the dimesnion
@@ -169,7 +151,6 @@ na_parse_narray_index(VALUE a, int orig_dim, ssize_t size, na_index_arg_t *q)
     q->orig_dim = orig_dim;
 }
 
-#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
 static void
 na_parse_range(VALUE range, ssize_t step, int orig_dim, ssize_t size, na_index_arg_t *q)
 {
@@ -178,6 +159,7 @@ na_parse_range(VALUE range, ssize_t step, int orig_dim, ssize_t size, na_index_a
     ssize_t beg, end, beg_orig, end_orig;
     const char *dot = "..", *edot = "...";
 
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
     rb_arithmetic_sequence_components_t x;
     rb_arithmetic_sequence_extract(range, &x);
     step = NUM2SSIZET(x.step);
@@ -212,21 +194,7 @@ na_parse_range(VALUE range, ssize_t step, int orig_dim, ssize_t size, na_index_a
                      beg_orig, dot, end_orig, size);
         }
     }
-    n = (end-beg)/step+1;
-    if (n<0) n=0;
-    na_index_set_step(q,orig_dim,n,beg,step);
-
-}
 #else
-
-static void
-na_parse_range(VALUE range, ssize_t step, int orig_dim, ssize_t size, na_index_arg_t *q)
-{
-    int n;
-    VALUE excl_end;
-    ssize_t beg, end, beg_orig, end_orig;
-    const char *dot = "..", *edot = "...";
-
     beg = beg_orig = NUM2SSIZET(rb_funcall(range,id_beg,0));
     if (beg < 0) {
         beg += size;
@@ -245,18 +213,18 @@ na_parse_range(VALUE range, ssize_t step, int orig_dim, ssize_t size, na_index_a
                  "%"SZF"d%s%"SZF"d is out of range for size=%"SZF"d",
                  beg_orig, dot, end_orig, size);
     }
+#endif
     n = (end-beg)/step+1;
     if (n<0) n=0;
     na_index_set_step(q,orig_dim,n,beg,step);
 
 }
-#endif
 
-static void
-na_parse_enumerator(VALUE enum_obj, int orig_dim, ssize_t size, na_index_arg_t *q)
+void
+na_parse_enumerator_step(VALUE enum_obj, VALUE *pstep )
 {
     int len;
-    ssize_t step;
+    VALUE step;
     struct enumerator *e;
 
     if (!RB_TYPE_P(enum_obj, T_DATA)) {
@@ -264,26 +232,40 @@ na_parse_enumerator(VALUE enum_obj, int orig_dim, ssize_t size, na_index_arg_t *
     }
     e = (struct enumerator *)DATA_PTR(enum_obj);
 
-    if (rb_obj_is_kind_of(e->obj, rb_cRange)) {
-        if (e->meth == id_each) {
-            na_parse_range(e->obj, 1, orig_dim, size, q);
-        }
-        else if (e->meth == id_step) {
-            if (TYPE(e->args) != T_ARRAY) {
-                rb_raise(rb_eArgError,"no argument for step");
-            }
-            len = RARRAY_LEN(e->args);
-            if (len != 1) {
-                rb_raise(rb_eArgError,"invalid number of step argument (1 for %d)",len);
-            }
-            step = NUM2SSIZET(RARRAY_AREF(e->args,0));
-            na_parse_range(e->obj, step, orig_dim, size, q);
-        } else {
-            rb_raise(rb_eTypeError,"unknown Range method: %s",rb_id2name(e->meth));
-        }
-    } else {
+    if (!rb_obj_is_kind_of(e->obj, rb_cRange)) {
         rb_raise(rb_eTypeError,"not Range object");
     }
+
+    if (e->meth == id_each) {
+        step = INT2NUM(1);
+    }
+    else if (e->meth == id_step) {
+        if (TYPE(e->args) != T_ARRAY) {
+            rb_raise(rb_eArgError,"no argument for step");
+        }
+        len = RARRAY_LEN(e->args);
+        if (len != 1) {
+            rb_raise(rb_eArgError,"invalid number of step argument (1 for %d)",len);
+        }
+        step = RARRAY_AREF(e->args,0);
+    } else {
+        rb_raise(rb_eTypeError,"unknown Range method: %s",rb_id2name(e->meth));
+    }
+    if (pstep) *pstep = step;
+}
+
+static void
+na_parse_enumerator(VALUE enum_obj, int orig_dim, ssize_t size, na_index_arg_t *q)
+{
+    VALUE step;
+    struct enumerator *e;
+
+    if (!RB_TYPE_P(enum_obj, T_DATA)) {
+        rb_raise(rb_eTypeError,"wrong argument type (not T_DATA)");
+    }
+    na_parse_enumerator_step(enum_obj, &step);
+    e = (struct enumerator *)DATA_PTR(enum_obj);
+    na_parse_range(e->obj, NUM2SSIZET(step), orig_dim, size, q); // e->obj : Range Object
 }
 
 // Analyze *a* which is *i*-th index object and store the information to q
@@ -352,13 +334,6 @@ na_index_parse_each(volatile VALUE a, ssize_t size, int i, na_index_arg_t *q)
         else if (rb_obj_is_kind_of(a, rb_cEnumerator)) {
             na_parse_enumerator(a, i, size, q);
         }
-#ifndef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
-        else if (rb_obj_is_kind_of(a, na_cStep)) {
-            ssize_t beg, step, n;
-            nary_step_array_index(a, size, (size_t*)(&n), &beg, &step);
-            na_index_set_step(q,i,n,beg,step);
-        }
-#endif
         // NArray index
         else if (NA_IsNArray(a)) {
             na_parse_narray_index(a, i, size, q);

--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -42,7 +42,9 @@ VALUE sym_option;
 VALUE sym_loop_opt;
 VALUE sym_init;
 
+#ifndef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
 VALUE na_cStep;
+#endif
 #ifndef HAVE_RB_CCOMPLEX
 VALUE rb_cComplex;
 #endif
@@ -52,7 +54,9 @@ int numo_na_inspect_cols=80;
 
 void Init_nary_data();
 void Init_nary_ndloop();
+#ifndef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
 void Init_nary_step();
+#endif
 void Init_nary_index();
 void Init_numo_bit();
 void Init_numo_int8();
@@ -1563,6 +1567,9 @@ na_get_reduce_flag_from_axes(VALUE na_obj, VALUE axes)
     size_t m;
     VALUE reduce;
     narray_t *na;
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+    VALUE rb_cArithSeq = rb_path2class("Enumerator::ArithmeticSequence");
+#endif
 
     GetNArray(na_obj,na);
     ndim = na->ndim;
@@ -1584,7 +1591,11 @@ na_get_reduce_flag_from_axes(VALUE na_obj, VALUE axes)
             step = 0;
             //printf("beg=%d step=%d len=%d\n",beg,step,len);
         } else if (rb_obj_is_kind_of(v,rb_cRange) ||
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+                   rb_obj_is_kind_of(v,rb_cArithSeq)) {
+#else
                    rb_obj_is_kind_of(v,na_cStep)) {
+#endif
             nary_step_array_index( v, ndim, &len, &beg, &step );
         } else {
             rb_raise(nary_eDimensionError, "invalid dimension argument %s",
@@ -1999,7 +2010,9 @@ Init_narray()
     sym_loop_opt = ID2SYM(rb_intern("loop_opt"));
     sym_init     = ID2SYM(rb_intern("init"));
 
+#ifndef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
     Init_nary_step();
+#endif
     Init_nary_index();
 
     Init_nary_data();

--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -42,9 +42,6 @@ VALUE sym_option;
 VALUE sym_loop_opt;
 VALUE sym_init;
 
-#ifndef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
-VALUE na_cStep;
-#endif
 #ifndef HAVE_RB_CCOMPLEX
 VALUE rb_cComplex;
 #endif
@@ -1594,7 +1591,7 @@ na_get_reduce_flag_from_axes(VALUE na_obj, VALUE axes)
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
                    rb_obj_is_kind_of(v,rb_cArithSeq)) {
 #else
-                   rb_obj_is_kind_of(v,na_cStep)) {
+                   rb_obj_is_kind_of(v,rb_cEnumerator)) {
 #endif
             nary_step_array_index( v, ndim, &len, &beg, &step );
         } else {

--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -45,6 +45,9 @@ VALUE sym_init;
 #ifndef HAVE_RB_CCOMPLEX
 VALUE rb_cComplex;
 #endif
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+VALUE rb_cArithSeq;
+#endif
 
 int numo_na_inspect_rows=20;
 int numo_na_inspect_cols=80;
@@ -1564,9 +1567,6 @@ na_get_reduce_flag_from_axes(VALUE na_obj, VALUE axes)
     size_t m;
     VALUE reduce;
     narray_t *na;
-#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
-    VALUE rb_cArithSeq = rb_path2class("Enumerator::ArithmeticSequence");
-#endif
 
     GetNArray(na_obj,na);
     ndim = na->ndim;
@@ -1903,6 +1903,9 @@ Init_narray()
 #ifndef HAVE_RB_CCOMPLEX
     rb_require("complex");
     rb_cComplex = rb_const_get(rb_cObject, rb_intern("Complex"));
+#endif
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+    rb_cArithSeq = rb_path2class("Enumerator::ArithmeticSequence");
 #endif
 
     rb_define_const(cNArray, "VERSION", rb_str_new2(NARRAY_VERSION));

--- a/ext/numo/narray/numo/intern.h
+++ b/ext/numo/narray/numo/intern.h
@@ -99,6 +99,7 @@ bool nary_test_reduce(VALUE reduce, int dim);
 
 void nary_step_array_index(VALUE self, size_t ary_size, size_t *plen, ssize_t *pbeg, ssize_t *pstep);
 void nary_step_sequence(VALUE self, size_t *plen, double *pbeg, double *pstep);
+void na_parse_enumerator_step(VALUE enum_obj, VALUE *pstep );
 
 // used in aref, aset
 #define na_get_result_dimension nary_get_result_dimension

--- a/ext/numo/narray/numo/narray.h
+++ b/ext/numo/narray/numo/narray.h
@@ -168,6 +168,9 @@ extern VALUE numo_cRObject;
 #ifndef HAVE_RB_CCOMPLEX
 extern VALUE rb_cComplex;
 #endif
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+VALUE rb_cArithSeq;
+#endif
 
 extern VALUE sym_reduce;
 extern VALUE sym_option;

--- a/ext/numo/narray/numo/narray.h
+++ b/ext/numo/narray/numo/narray.h
@@ -165,9 +165,6 @@ extern VALUE numo_cUInt32;
 extern VALUE numo_cUInt16;
 extern VALUE numo_cUInt8;
 extern VALUE numo_cRObject;
-#ifndef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
-extern VALUE na_cStep;
-#endif
 #ifndef HAVE_RB_CCOMPLEX
 extern VALUE rb_cComplex;
 #endif
@@ -236,6 +233,23 @@ typedef struct {
     unsigned int element_stride;
 } narray_type_info_t;
 
+// from ruby/enumerator.c
+struct enumerator {
+    VALUE obj;
+    ID    meth;
+    VALUE args;
+    // use only above in this source
+    VALUE fib;
+    VALUE dst;
+    VALUE lookahead;
+    VALUE feedvalue;
+    VALUE stop_exc;
+    VALUE size;
+    // incompatible below depending on ruby version
+    //VALUE procs;                      // ruby 2.4
+    //rb_enumerator_size_func *size_fn; // ruby 2.1-2.4
+    //VALUE (*size_fn)(ANYARGS);        // ruby 2.0
+};
 
 static inline narray_t *
 na_get_narray_t(VALUE obj)

--- a/ext/numo/narray/numo/narray.h
+++ b/ext/numo/narray/numo/narray.h
@@ -165,7 +165,9 @@ extern VALUE numo_cUInt32;
 extern VALUE numo_cUInt16;
 extern VALUE numo_cUInt8;
 extern VALUE numo_cRObject;
+#ifndef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
 extern VALUE na_cStep;
+#endif
 #ifndef HAVE_RB_CCOMPLEX
 extern VALUE rb_cComplex;
 #endif

--- a/ext/numo/narray/step.c
+++ b/ext/numo/narray/step.c
@@ -218,7 +218,7 @@ nary_step_sequence( VALUE obj, size_t *plen, double *pbeg, double *pstep )
     vlen = rb_ivar_get(obj, id_len);
 
     if (RTEST(vlen)) {
-        size = NUM2SIZET(vlen); //
+        size = NUM2SIZET(vlen);
 
         if (!RTEST(vstep)) {
             if (RTEST(vend)) {
@@ -257,7 +257,7 @@ nary_step_sequence( VALUE obj, size_t *plen, double *pbeg, double *pstep )
             if (isinf(dsize) || isnan(dsize)) {
                 rb_raise(rb_eArgError, "not finite size");
             }
-            size = dsize; //
+            size = dsize;
         } else {
             rb_raise(rb_eArgError, "cannot determine length argument");
         }

--- a/ext/numo/narray/step.c
+++ b/ext/numo/narray/step.c
@@ -29,6 +29,7 @@ static ID id_beg, id_end, id_len, id_step, id_excl;
 //#define EXCL(r) RTEST(rb_ivar_get((r), id_excl))
 #define EXCL(r) RTEST(rb_funcall((r), rb_intern("exclude_end?"), 0))
 
+#ifndef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
 #define SET_EXCL(r,v) rb_ivar_set((r), id_excl, (v) ? Qtrue : Qfalse)
 
 static void
@@ -181,6 +182,7 @@ step_exclude_end_p(VALUE self)
 {
     return RTEST(rb_ivar_get(self, id_excl)) ? Qtrue : Qfalse;
 }
+#endif
 
 
 /*
@@ -335,15 +337,30 @@ nary_step_sequence( VALUE self, size_t *plen, double *pbeg, double *pstep )
     double dbeg, dend, dstep=1, dsize, err;
     size_t size, n;
 
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+    rb_arithmetic_sequence_components_t x;
+    rb_arithmetic_sequence_extract(self, &x);
+
+    vbeg = x.begin;
+#else
     //vbeg = rb_ivar_get(self, id_beg);
     vbeg = rb_funcall(self, id_beg, 0);
+#endif
     dbeg = NUM2DBL(vbeg);
 
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+    vend = x.end;
+#else
     //vend = rb_ivar_get(self, id_end);
     vend = rb_funcall(self, id_end, 0);
+#endif
 
     vlen = rb_ivar_get(self, id_len);
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+    vstep = x.step;
+#else
     vstep = rb_ivar_get(self, id_step);
+#endif
     //vlen  = rb_funcall(self, id_len ,0);
     //vstep = rb_funcall(self, id_step,0);
 
@@ -398,6 +415,7 @@ nary_step_sequence( VALUE self, size_t *plen, double *pbeg, double *pstep )
     if (pstep) *pstep = dstep;
 }
 
+#ifndef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
 /*
 static VALUE
 step_each( VALUE self )
@@ -472,3 +490,4 @@ Init_nary_step()
     id_step = rb_intern("step");
     id_excl = rb_intern("excl");
 }
+#endif

--- a/ext/numo/narray/step.c
+++ b/ext/numo/narray/step.c
@@ -24,166 +24,10 @@
 #define DBL_EPSILON 2.2204460492503131e-16
 #endif
 
-static ID id_beg, id_end, id_len, id_step, id_excl;
+static ID id_beg, id_end, id_len, id_step;
 
-//#define EXCL(r) RTEST(rb_ivar_get((r), id_excl))
+
 #define EXCL(r) RTEST(rb_funcall((r), rb_intern("exclude_end?"), 0))
-
-#ifndef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
-#define SET_EXCL(r,v) rb_ivar_set((r), id_excl, (v) ? Qtrue : Qfalse)
-
-static void
-step_init(
-  VALUE self,
-  VALUE beg,
-  VALUE end,
-  VALUE step,
-  VALUE len,
-  VALUE excl
-)
-{
-    if (RTEST(len)) {
-        if (!(FIXNUM_P(len) || TYPE(len)==T_BIGNUM)) {
-            rb_raise(rb_eArgError, "length must be Integer");
-        }
-        if (RTEST(rb_funcall(len,rb_intern("<"),1,INT2FIX(0)))) {
-            rb_raise(rb_eRangeError,"length must be non negative");
-        }
-    }
-    rb_ivar_set(self, id_beg, beg);
-    rb_ivar_set(self, id_end, end);
-    rb_ivar_set(self, id_len, len);
-    rb_ivar_set(self, id_step, step);
-    SET_EXCL(self, excl);
-}
-
-static VALUE
-nary_step_new2(
-  VALUE range,
-  VALUE step,
-  VALUE len
-)
-{
-    VALUE beg, end, excl;
-    VALUE self = rb_obj_alloc(na_cStep);
-
-    //beg = rb_ivar_get(range, id_beg);
-    beg = rb_funcall(range, id_beg, 0);
-    //end = rb_ivar_get(range, id_end);
-    end = rb_funcall(range, id_end, 0);
-    excl = rb_funcall(range, rb_intern("exclude_end?"), 0);
-
-    step_init(self, beg, end, step, len, excl);
-    return self;
-}
-
-
-/*
- *  call-seq:
- *     Step.new(start, end, step=nil, length=nil)    => step
- *     Step.new(range, step=nil, length=nil)         => step
- *
- *  Constructs a step using three parameters among <i>start</i>,
- *  <i>end</i>, <i>step</i> and <i>length</i>.  <i>start</i>,
- *  <i>end</i> parameters can be replaced with <i>range</i>.  If the
- *  <i>step</i> is omitted (or supplied with nil), then calculated
- *  from <i>length</i> or definded as 1.
- */
-
-static VALUE
-step_initialize( int argc, VALUE *argv, VALUE self )
-{
-    VALUE a, b=Qnil, c=Qnil, d=Qnil, e=Qnil;
-
-    rb_scan_args(argc, argv, "13", &a, &b, &c, &d);
-    /* Selfs are immutable, so that they should be initialized only once. */
-    if (rb_ivar_defined(self, id_beg)) {
-        rb_name_error(rb_intern("initialize"), "`initialize' called twice");
-    }
-    if (rb_obj_is_kind_of(a,rb_cRange)) {
-        if (argc>3) {
-            rb_raise(rb_eArgError, "extra argument");
-        }
-        d = c;
-        c = b;
-        e = rb_funcall(a, rb_intern("exclude_end?"), 0);
-        //b = rb_ivar_get(a, id_end);
-        b = rb_funcall(a, id_end, 0);
-        //a = rb_ivar_get(a, id_beg);
-        a = rb_funcall(a, id_beg, 0);
-    }
-    step_init(self, a, b, c, d, e);
-    return Qnil;
-}
-
-/*
- *  call-seq:
- *     step.begin  => obj
- *     step.first  => obj
- *
- *  Returns the start of <i>step</i>.
- */
-
-static VALUE
-step_first( VALUE self )
-{
-    return rb_ivar_get(self, id_beg);
-}
-
-/*
- *  call-seq:
- *     step.end    => obj
- *     step.last   => obj
- *
- *  Returns the object that defines the end of <i>step</i>.
- */
-
-static VALUE
-step_last( VALUE self )
-{
-    return rb_ivar_get(self, id_end);
-}
-
-/*
- *  call-seq:
- *     step.length  => obj
- *     step.size    => obj
- *
- *  Returns the length of <i>step</i>.
- */
-
-static VALUE
-step_length( VALUE self )
-{
-    return rb_ivar_get(self, id_len);
-}
-
-/*
- *  call-seq:
- *     step.step    => obj
- *
- *  Returns the step of <i>step</i>.
- */
-
-static VALUE
-step_step( VALUE self )
-{
-    return rb_ivar_get(self, id_step);
-}
-
-/*
- *  call-seq:
- *     step.exclude_end?    => true or false
- *
- *  Returns <code>true</code> if <i>step</i> excludes its end value.
- */
-static VALUE
-step_exclude_end_p(VALUE self)
-{
-    return RTEST(rb_ivar_get(self, id_excl)) ? Qtrue : Qfalse;
-}
-#endif
-
 
 /*
  *  call-seq:
@@ -194,7 +38,7 @@ step_exclude_end_p(VALUE self)
  */
 
 void
-nary_step_array_index(VALUE self, size_t ary_size,
+nary_step_array_index(VALUE obj, size_t ary_size,
                       size_t *plen, ssize_t *pbeg, ssize_t *pstep)
 {
     size_t len;
@@ -202,14 +46,28 @@ nary_step_array_index(VALUE self, size_t ary_size,
     VALUE vbeg, vend, vstep, vlen;
     ssize_t end=ary_size;
 
-    //vbeg = rb_ivar_get(self, id_beg);
-    //vend = rb_ivar_get(self, id_end);
-    vlen = rb_ivar_get(self, id_len);
-    vstep = rb_ivar_get(self, id_step);
-    vbeg = rb_funcall(self, id_beg, 0);
-    vend = rb_funcall(self, id_end, 0);
-    //vlen = rb_funcall(self, id_len, 0);
-    //vstep = rb_funcall(self, id_step, 0);
+#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+    rb_arithmetic_sequence_components_t x;
+    rb_arithmetic_sequence_extract(obj, &x);
+
+    vstep = x.step;
+    vbeg = x.begin;
+    vend = x.end;
+#else
+    struct enumerator *e;
+
+    if (rb_obj_is_kind_of(obj, rb_cRange)) {
+        vstep = rb_ivar_get(obj, id_step);
+    } else { // Enumerator
+        na_parse_enumerator_step(obj, &vstep);
+        e = (struct enumerator *)DATA_PTR(obj);
+        obj =  e->obj; // Range
+    }
+
+    vbeg = rb_funcall(obj, id_beg, 0);
+    vend = rb_funcall(obj, id_end, 0);
+#endif
+    vlen = rb_ivar_get(obj, id_len);
 
     if (RTEST(vbeg)) {
         beg = NUM2SSIZET(vbeg);
@@ -239,7 +97,7 @@ nary_step_array_index(VALUE self, size_t ary_size,
                     }
                 } else {
                     if (RTEST(vend)) {
-                        if (EXCL(self)) {
+                        if (EXCL(obj)) {
                             if (step>0) end--;
                             if (step<0) end++;
                         }
@@ -253,7 +111,7 @@ nary_step_array_index(VALUE self, size_t ary_size,
                 step = 1;
                 if (RTEST(vbeg)) {
                     if (RTEST(vend)) {
-                        if (EXCL(self)) {
+                        if (EXCL(obj)) {
                             if (beg<end) end--;
                             if (beg>end) end++;
                         }
@@ -264,7 +122,7 @@ nary_step_array_index(VALUE self, size_t ary_size,
                     }
                 } else {
                     if (RTEST(vend)) {
-                        if (EXCL(self)) {
+                        if (EXCL(obj)) {
                             end--;
                         }
                         beg = end - (len-1);
@@ -288,7 +146,7 @@ nary_step_array_index(VALUE self, size_t ary_size,
             if (!RTEST(vend)) {
                 end = ary_size-1;
             }
-            else if (EXCL(self)) {
+            else if (EXCL(obj)) {
                 end--;
             }
             if (beg<=end) {
@@ -303,7 +161,7 @@ nary_step_array_index(VALUE self, size_t ary_size,
             if (!RTEST(vend)) {
                 end = 0;
             }
-            else if (EXCL(self)) {
+            else if (EXCL(obj)) {
                 end++;
             }
             if (beg>=end) {
@@ -329,48 +187,43 @@ nary_step_array_index(VALUE self, size_t ary_size,
     if (pstep) *pstep = step;
 }
 
-
 void
-nary_step_sequence( VALUE self, size_t *plen, double *pbeg, double *pstep )
+nary_step_sequence( VALUE obj, size_t *plen, double *pbeg, double *pstep )
 {
-    VALUE vbeg, vend, vstep, vlen;
+    VALUE vend, vstep, vlen;
     double dbeg, dend, dstep=1, dsize, err;
     size_t size, n;
 
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
     rb_arithmetic_sequence_components_t x;
-    rb_arithmetic_sequence_extract(self, &x);
+    rb_arithmetic_sequence_extract(obj, &x);
 
-    vbeg = x.begin;
-#else
-    //vbeg = rb_ivar_get(self, id_beg);
-    vbeg = rb_funcall(self, id_beg, 0);
-#endif
-    dbeg = NUM2DBL(vbeg);
-
-#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
+    vstep = x.step;
+    dbeg = NUM2DBL(x.begin);
     vend = x.end;
 #else
-    //vend = rb_ivar_get(self, id_end);
-    vend = rb_funcall(self, id_end, 0);
-#endif
+    struct enumerator *e;
 
-    vlen = rb_ivar_get(self, id_len);
-#ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
-    vstep = x.step;
-#else
-    vstep = rb_ivar_get(self, id_step);
+    if (rb_obj_is_kind_of(obj, rb_cRange)) {
+        vstep = rb_ivar_get(obj, id_step);
+    } else { // Enumerator
+        na_parse_enumerator_step(obj, &vstep);
+        e = (struct enumerator *)DATA_PTR(obj);
+        obj =  e->obj; // Range
+    }
+
+    dbeg = NUM2DBL(rb_funcall(obj, id_beg, 0));
+    vend = rb_funcall(obj, id_end, 0);
 #endif
-    //vlen  = rb_funcall(self, id_len ,0);
-    //vstep = rb_funcall(self, id_step,0);
+    vlen = rb_ivar_get(obj, id_len);
 
     if (RTEST(vlen)) {
-        size = NUM2SIZET(vlen);
+        size = NUM2SIZET(vlen); //
 
         if (!RTEST(vstep)) {
             if (RTEST(vend)) {
                 dend = NUM2DBL(vend);
-                if (EXCL(self)) {
+                if (EXCL(obj)) {
                     n = size;
                 } else {
                     n = size-1;
@@ -395,7 +248,7 @@ nary_step_sequence( VALUE self, size_t *plen, double *pbeg, double *pstep )
             err = (fabs(dbeg)+fabs(dend)+fabs(dend-dbeg))/fabs(dstep)*DBL_EPSILON;
             if (err>0.5) err=0.5;
             dsize = (dend-dbeg)/dstep;
-            if (EXCL(self))
+            if (EXCL(obj))
                 dsize -= err;
             else
                 dsize += err;
@@ -404,7 +257,7 @@ nary_step_sequence( VALUE self, size_t *plen, double *pbeg, double *pstep )
             if (isinf(dsize) || isnan(dsize)) {
                 rb_raise(rb_eArgError, "not finite size");
             }
-            size = dsize;
+            size = dsize; //
         } else {
             rb_raise(rb_eArgError, "cannot determine length argument");
         }
@@ -415,79 +268,13 @@ nary_step_sequence( VALUE self, size_t *plen, double *pbeg, double *pstep )
     if (pstep) *pstep = dstep;
 }
 
-#ifndef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
-/*
-static VALUE
-step_each( VALUE self )
-{
-    VALUE  a;
-    double beg, step;
-    size_t i, size;
-
-    a = nary_step_parameters( self, Qnil );
-    beg  = NUM2DBL(RARRAY_PTR(a)[0]);
-    step = NUM2DBL(RARRAY_PTR(a)[1]);
-    size = NUM2SIZET(RARRAY_PTR(a)[2]);
-
-    for (i=0; i<size; i++) {
-        rb_yield(rb_float_new(beg+i*step));
-    }
-    return self;
-}
-*/
-
-static VALUE
-range_with_step( VALUE range, VALUE step )
-{
-    return nary_step_new2( range, step, Qnil );
-}
-
-static VALUE
-range_with_length( VALUE range, VALUE len )
-{
-    return nary_step_new2( range, Qnil, len );
-}
-
-
-static VALUE
-nary_s_step( int argc, VALUE *argv, VALUE mod )
-{
-    VALUE self = rb_obj_alloc(na_cStep);
-    step_initialize(argc, argv, self);
-    return self;
-}
-
-
 void
 Init_nary_step()
 {
-    na_cStep = rb_define_class_under(cNArray, "Step", rb_cObject);
-    rb_include_module(na_cStep, rb_mEnumerable);
-    rb_define_method(na_cStep, "initialize", step_initialize, -1);
-
-    //rb_define_method(na_cStep, "each", step_each, 0);
-
-    rb_define_method(na_cStep, "first", step_first, 0);
-    rb_define_method(na_cStep, "last", step_last, 0);
-    rb_define_method(na_cStep, "begin", step_first, 0);
-    rb_define_method(na_cStep, "end", step_last, 0);
-    rb_define_method(na_cStep, "step", step_step, 0);
-    rb_define_method(na_cStep, "length", step_length, 0);
-    rb_define_method(na_cStep, "size", step_length, 0);
-    rb_define_method(na_cStep, "exclude_end?", step_exclude_end_p, 0);
-    //rb_define_method(na_cStep, "to_s", step_to_s, 0);
-    //rb_define_method(na_cStep, "inspect", step_inspect, 0);
-    //rb_define_method(na_cStep, "parameters", nary_step_parameters, 1);
-
-    rb_define_method(rb_cRange, "%", range_with_step, 1);
-    rb_define_method(rb_cRange, "*", range_with_length, 1);
-
-    rb_define_singleton_method(cNArray, "step", nary_s_step, -1);
+    rb_define_alias(rb_cRange, "%", "step");
 
     id_beg  = rb_intern("begin");
     id_end  = rb_intern("end");
     id_len  = rb_intern("length");
     id_step = rb_intern("step");
-    id_excl = rb_intern("excl");
 }
-#endif

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -93,6 +93,7 @@ class NArrayTest < Test::Unit::TestCase
         assert { a[(-5..-1) % 2] == [2,5,11] }
         assert { a[(-5...-1) % 2] == [2,5] }
         assert { a[[4,3,0,1,5,2]] == [7,5,1,2,11,3] } #  Numo::NArray::CastError: cannot convert to NArray
+        assert { a.reverse == [11,7,5,3,2,1] }
         assert { a.sum == 29 }
         if float_types.include?(dtype)
           assert { a.mean == 29.0/6 }
@@ -223,6 +224,11 @@ class NArrayTest < Test::Unit::TestCase
         assert { a.transpose(1,0) == [[1,5],[2,7],[3,11]] }
         assert { a.triu == [[1,2,3],[0,7,11]] }
         assert { a.tril == [[1,0,0],[5,7,0]] }
+        assert { a.reverse == [[11,7,5],[3,2,1]] }
+        assert { a.reverse(0,1) == [[11,7,5],[3,2,1]] }
+        assert { a.reverse(1,0) == [[11,7,5],[3,2,1]] }
+        assert { a.reverse(0) == [[5,7,11],[1,2,3]] }
+        assert { a.reverse(1) == [[3,2,1],[11,7,5]] }
 
         assert { a.sum == 29 }
         assert { a.sum(0) == [6, 9, 14] }
@@ -302,6 +308,23 @@ class NArrayTest < Test::Unit::TestCase
       assert { a.transpose == [[[1,5],[3,7]],[[2,6],[4,8]]] }
       assert { a.transpose(2,1,0) == [[[1,5],[3,7]],[[2,6],[4,8]]] }
       assert { a.transpose(0,2,1) == [[[1,3],[2,4]],[[5,7],[6,8]]] }
+
+      assert { a.reverse           == [[[8,7],[6,5]],[[4,3],[2,1]]] }
+      assert { a.reverse(0,1,2)    == [[[8,7],[6,5]],[[4,3],[2,1]]] }
+      assert { a.reverse(-3,-2,-1) == [[[8,7],[6,5]],[[4,3],[2,1]]] }
+      assert { a.reverse(0..2)     == [[[8,7],[6,5]],[[4,3],[2,1]]] }
+      assert { a.reverse(-3..-1)   == [[[8,7],[6,5]],[[4,3],[2,1]]] }
+#      assert { a.reverse(-3...0)   == [[[8,7],[6,5]],[[4,3],[2,1]]] } # not support yet
+      assert { a.reverse(0...3)    == [[[8,7],[6,5]],[[4,3],[2,1]]] }
+      assert { a.reverse(0)        == [[[5,6],[7,8]],[[1,2],[3,4]]] }
+      assert { a.reverse(1)        == [[[3,4],[1,2]],[[7,8],[5,6]]] }
+      assert { a.reverse(2)        == [[[2,1],[4,3]],[[6,5],[8,7]]] }
+      assert { a.reverse(0,1)      == [[[7,8],[5,6]],[[3,4],[1,2]]] }
+      assert { a.reverse(0..1)     == [[[7,8],[5,6]],[[3,4],[1,2]]] }
+      assert { a.reverse(0...2)    == [[[7,8],[5,6]],[[3,4],[1,2]]] }
+      assert { a.reverse(0,2)      == [[[6,5],[8,7]],[[2,1],[4,3]]] }
+      assert { a.reverse((0..2) % 2) == [[[6,5],[8,7]],[[2,1],[4,3]]] }
+      assert { a.reverse((0..2).step(2)) == [[[6,5],[8,7]],[[2,1],[4,3]]] }
 
       assert { a.contiguous? }
       assert { a.transpose.contiguous? == false }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -67,6 +67,17 @@ class NArrayTest < Test::Unit::TestCase
           assert { a[0.step(-1,2)] == [1,3,7] }
           assert { a[0.step(4,2)] == [1,3,7] }
           assert { a[-5.step(-1,2)] == [2,5,11] }
+
+          assert { a[0.step] == [1,2,3,5,7,11] }
+          assert { a[-5.step] == [2,3,5,7,11] }
+          assert { eval('a[(0..).step(2)]') == [1,3,7] }
+          assert { eval('a[(0...).step(2)]') == [1,3,7] }
+          assert { eval('a[(-5..).step(2)]') == [2,5,11] }
+          assert { eval('a[(-5...).step(2)]') == [2,5,11] }
+          assert { eval('a[(0..) % 2]') == [1,3,7] }
+          assert { eval('a[(0...) % 2]') == [1,3,7] }
+          assert { eval('a[(-5..) % 2]') == [2,5,11] }
+          assert { eval('a[(-5...) % 2]') == [2,5,11] }
         end
 
         assert { a[(0..-1).step(2)] == [1,3,7] }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -314,7 +314,6 @@ class NArrayTest < Test::Unit::TestCase
       assert { a.reverse(-3,-2,-1) == [[[8,7],[6,5]],[[4,3],[2,1]]] }
       assert { a.reverse(0..2)     == [[[8,7],[6,5]],[[4,3],[2,1]]] }
       assert { a.reverse(-3..-1)   == [[[8,7],[6,5]],[[4,3],[2,1]]] }
-#      assert { a.reverse(-3...0)   == [[[8,7],[6,5]],[[4,3],[2,1]]] } # not support yet
       assert { a.reverse(0...3)    == [[[8,7],[6,5]],[[4,3],[2,1]]] }
       assert { a.reverse(0)        == [[[5,6],[7,8]],[[1,2],[3,4]]] }
       assert { a.reverse(1)        == [[[3,4],[1,2]],[[7,8],[5,6]]] }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -57,7 +57,31 @@ class NArrayTest < Test::Unit::TestCase
         assert { a[3..4] == [5,7] }
         assert { a[5] == 11 }
         assert { a[-1] == 11 }
-        assert { a[[4,3,0,1,5,2]] == [7,5,1,2,11,3] }
+        assert { a[(0..-1).each] == [1,2,3,5,7,11] }
+        assert { a[(0...-1).each] == [1,2,3,5,7] }
+
+        if Enumerator.const_defined?(:ArithmeticSequence)
+          assert { a[0.step(-1)] == [1,2,3,5,7,11] }
+          assert { a[0.step(4)] == [1,2,3,5,7] }
+          assert { a[-5.step(-1)] == [2,3,5,7,11] }
+          assert { a[0.step(-1,2)] == [1,3,7] }
+          assert { a[0.step(4,2)] == [1,3,7] }
+          assert { a[-5.step(-1,2)] == [2,5,11] }
+        end
+
+        assert { a[(0..-1).step(2)] == [1,3,7] }
+        assert { a[(0...-1).step(2)] == [1,3,7] }
+        assert { a[(0..4).step(2)] == [1,3,7] }
+        assert { a[(0...4).step(2)] == [1,3] }
+        assert { a[(-5..-1).step(2)] == [2,5,11] }
+        assert { a[(-5...-1).step(2)] == [2,5] }
+        assert { a[(0..-1) % 2] == [1,3,7] }
+        assert { a[(0...-1) % 2] == [1,3,7] }
+        assert { a[(0..4) % 2] == [1,3,7] }
+        assert { a[(0...4) % 2] == [1,3] }
+        assert { a[(-5..-1) % 2] == [2,5,11] }
+        assert { a[(-5...-1) % 2] == [2,5] }
+        assert { a[[4,3,0,1,5,2]] == [7,5,1,2,11,3] } #  Numo::NArray::CastError: cannot convert to NArray
         assert { a.sum == 29 }
         if float_types.include?(dtype)
           assert { a.mean == 29.0/6 }
@@ -105,6 +129,40 @@ class NArrayTest < Test::Unit::TestCase
 
     test "#{dtype},[1..4]" do
       assert { dtype[1..4] == [1,2,3,4] }
+    end
+
+    test "#{dtype},[-4..-1]" do
+      assert { dtype[-4..-1] == [-4,-3,-2,-1] }
+    end
+
+    if Enumerator.const_defined?(:ArithmeticSequence)
+      test "#{dtype},[1.step(4)]" do
+        assert { dtype[1.step(4)] == [1,2,3,4] }
+      end
+
+      test "#{dtype},[-4.step(-1)]" do
+        assert { dtype[-4.step(-1)] == [-4,-3,-2,-1] }
+      end
+
+      test "#{dtype},[1.step(4, 2)]" do
+        assert { dtype[1.step(4, 2)] == [1,3] }
+      end
+
+      test "#{dtype},[-4.step(-1, 2)]" do
+        assert { dtype[-4.step(-1, 2)] == [-4,-2] }
+      end
+
+      test "#{dtype},[(-4..-1).step(2)]" do
+        assert { dtype[(-4..-1).step(2)] == [-4,-2] }
+      end
+    end
+
+    test "#{dtype},[(1..4) % 2]" do
+      assert { dtype[(1..4) % 2] == [1,3] }
+    end
+
+    test "#{dtype},[(-4..-1) % 2]" do
+      assert { dtype[(-4..-1) % 2] == [-4,-2] }
     end
 
     #test "#{dtype}.seq(5)" do


### PR DESCRIPTION
I am working on supporting arithmetic sequences in Ruby 2.6.
Please tell me because there are unclear points in this work.

## Numo::NArray Slicing and Store List of patterns.

|   |  | Ruby |  | return |  | Numo slicing support |  | Numo store  support|  |  | api |  |  |  |  |  |  |  |  |
| --- | --- | :---: | :---: | --- | --- | :---: | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
|  object | sample | 2.5 | 2.6 | return (value) | return (class) | now | this PR | now | this PR | to_a(Array) | begin | end | first | first(2) | last | last(2) | step | exclude_end? | length |
|  Array | [1, 3, 5, 7, 9] | o |  |  | Array | o | o | o | o | <= | - | - | 1 | [1, 3] | 9 | [7, 9] | - | - | 10 |
|  Range | 1..10 | o |  | 1..10 | Range | o | o | o | o | [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 1 | 10 | 1 | [1, 2] | 10 | [9, 10] |  #<Enumerator: 1..10:step> | FALSE | - |
|   | 1...10 | o |  | 1...10 | Range | o | o | o | o | [1, 2, 3, 4, 5, 6, 7, 8, 9] | 1 | 10 | 1 | [1, 2] | 9 | [8, 9] |  #<Enumerator: 1...10:step> | TRUE | - |
|  Integer#step | 1.step(10) | o | - | #<Enumerator: 1:step(10)> | Enumerable | - | - | - | - | [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | - | - | 1 | [1, 3] | - | - | - | - | - |
|   |  | - | o | (1.step(10)) | Enumerator::ArithmeticSequence | - | o | - | o | [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | 1 | 10 | 1 | [1, 3] | 10 | [9, 10] | 1 | FALSE | - |
|  Integer#step | 1.step(10, 2) | o | - | #<Enumerator: 1:step(10, 2)> | Enumerable | - | - | - | - | [1, 3, 5, 7, 9] | - | - | 1 | [1, 3] | - | - | - | - | - |
|   |  | - | o | (1.step(10, 2)) | Enumerator::ArithmeticSequence | - | o | - | o | [1, 3, 5, 7, 9] | 1 | 10 | 1 | [1, 3] | 9 | [7, 9] | 2 | FALSE | - |
|  Range#each | (1..10).each | o |  | #<Enumerator: 1..10:each> | **Enumerable** | o | o | o | o | [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] | - | - | 1 | [1, 2] | - | - | - | - | - |
|  Range#step | (1..10).step(2) | o | - | #<Enumerator: 1..10:step(2)> | **Enumerable** | o | o | o | o | [1, 3, 5, 7, 9] | - | - | 1 | [1, 3] | - | - | - | - | - |
|   |  | - | o | ((1..10).step(2)) | Enumerator::ArithmeticSequence | o | o | o | o | [1, 3, 5, 7, 9] | 1 | 10 | 1 | [1, 3] | 9 | [7, 9] | 2 | FALSE | - |
|   | (1...10).step(2) | o | - | #<Enumerator: 1...10:step(2)> | **Enumerable** | o | o | o | o | [1, 3, 5, 7, 9] | - | - | 1 | [1, 3] | - | - | - | - | - |
|   |  | - | o | ((1...10).step(2)) | Enumerator::ArithmeticSequence | o | o | o | o | [1, 3, 5, 7, 9] | 1 | 10 | 1 | [1, 3] | 9 | [7, 9] | 2 | TRUE | - |
|  Range#%<br/>(step alias,<br/>from 2.6) | (1..10) % 2 | - | o | ((1..10).%(2))  | Enumerator::ArithmeticSequence | - | o | - | o | [1, 3, 5, 7, 9] | 1 | 10 | 1 | [1, 3] | 9 | [7, 9] | 2 | FALSE | - |
|   |  | o | o | #<Numo::NArray::Step> | Numo::NArray::Step | o | - | o | - | - | 1 | 10 | 1 | - | `10` | - | 2 | FALSE | nii |
|   | (1...10) % 2 | - | o | ((1...10).%(2))  | Enumerator::ArithmeticSequence | - | o | - | o | [1, 3, 5, 7, 9] | 1 | 10 | 1 | [1, 3] | 9 | [7, 9] | 2 | TRUE | - |
|   |  | o | o | #<Numo::NArray::Step> | Numo::NArray::Step | o | - | o | - | - | 1 | 10 | 1 | - | `10` | - | 2 | TRUE | nil |
|   | (1...10) * 2 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |

## Question.

* Q1.: "(1...10) * 2" : How to use the "*" method of Range?
https://github.com/ruby-numo/numo-narray/blob/master/ext/numo/narray/step.c#L465
* Q2.: I'd like to change Numo::NArray::Step#last, because Numo::NArray::Step#last and Enumerator::ArithmeticSequence#last are incompatible, what do you think?
* Q3.: I would like to delete the Numo::NArray::Step class using Range#% as an alias of the Range#step, what do you think?


