### PR TITLE
extern is needed for the declaration of rb_cArithSeq in narray.h

### DIFF
--- a/ext/numo/narray/numo/narray.h
+++ b/ext/numo/narray/numo/narray.h
@@ -169,7 +169,7 @@ extern VALUE numo_cRObject;
 extern VALUE rb_cComplex;
 #endif
 #ifdef HAVE_RB_ARITHMETIC_SEQUENCE_EXTRACT
-VALUE rb_cArithSeq;
+extern VALUE rb_cArithSeq;
 #endif
 
 extern VALUE sym_reduce;


### PR DESCRIPTION
It prevents `duplicate symbol _rb_cArithSeq` link error.