### PR TITLE
at() method was rewritten in C.

### DIFF
--- a/ext/numo/narray/gen/spec.rb
+++ b/ext/numo/narray/gen/spec.rb
@@ -128,6 +128,7 @@ def_singleton_method "cast"
 
 def_method "aref", op:"[]"
 def_method "aset", op:"[]="
+def_method "at"
 
 def_method "coerce_cast"
 def_method "to_a"

--- a/ext/numo/narray/gen/tmpl/at.c
+++ b/ext/numo/narray/gen/tmpl/at.c
@@ -1,0 +1,34 @@
+/*
+  Multi-dimensional array indexing.
+  Same as [] for one-dimensional NArray.
+  Similar to numpy's tuple indexing, i.e., `a[[1,2,..],[3,4,..]]`
+  @overload at(*indices)
+  @param [Numeric,Range,etc] *indices  Multi-dimensional Index Arrays.
+  @return [Numo::NArray::<%=class_name%>] one-dimensional NArray view.
+
+  @example
+      x = Numo::DFloat.new(3,3,3).seq
+      => Numo::DFloat#shape=[3,3,3]
+       [[[0, 1, 2],
+         [3, 4, 5],
+         [6, 7, 8]],
+        [[9, 10, 11],
+         [12, 13, 14],
+         [15, 16, 17]],
+        [[18, 19, 20],
+         [21, 22, 23],
+         [24, 25, 26]]]
+
+      x.at([0,1,2],[0,1,2],[-1,-2,-3])
+      => Numo::DFloat(view)#shape=[3]
+       [2, 13, 24]
+ */
+static VALUE
+<%=c_func(-1)%>(int argc, VALUE *argv, VALUE self)
+{
+    int nd;
+    size_t pos;
+
+    nd = na_get_result_dimension(self, argc, argv, sizeof(dtype), &pos);
+    return na_at_main(argc, argv, self, 0, nd);
+}

--- a/ext/numo/narray/numo/intern.h
+++ b/ext/numo/narray/numo/intern.h
@@ -106,6 +106,7 @@ void na_parse_enumerator_step(VALUE enum_obj, VALUE *pstep );
 int nary_get_result_dimension(VALUE self, int argc, VALUE *argv, ssize_t stride, size_t *pos_idx);
 #define na_aref_main nary_aref_main
 VALUE nary_aref_main(int nidx, VALUE *idx, VALUE self, int keep_dim, int nd);
+VALUE na_at_main(int nidx, VALUE *idx, VALUE self, int keep_dim, int nd);
 
 #include "ruby/version.h"
 

--- a/lib/numo/narray/extra.rb
+++ b/lib/numo/narray/extra.rb
@@ -43,56 +43,6 @@ module Numo
       reverse(0)
     end
 
-    # Multi-dimensional array indexing.
-    # Same as [] for one-dimensional NArray.
-    # Similar to numpy's tuple indexing, i.e., `a[[1,2,..],[3,4,..]]`
-    # (This method will be rewritten in C)
-    # @return [Numo::NArray] one-dimensional view of self.
-    # @example
-    #   p x = Numo::DFloat.new(3,3,3).seq
-    #   # Numo::DFloat#shape=[3,3,3]
-    #   # [[[0, 1, 2],
-    #   #   [3, 4, 5],
-    #   #   [6, 7, 8]],
-    #   #  [[9, 10, 11],
-    #   #   [12, 13, 14],
-    #   #   [15, 16, 17]],
-    #   #  [[18, 19, 20],
-    #   #   [21, 22, 23],
-    #   #   [24, 25, 26]]]
-    #
-    #   p x.at([0,1,2],[0,1,2],[-1,-2,-3])
-    #   # Numo::DFloat(view)#shape=[3]
-    #   # [2, 13, 24]
-    def at(*indices)
-      if indices.size != ndim
-        raise DimensionError, "argument length does not match dimension size"
-      end
-      idx = nil
-      stride = 1
-      (indices.size-1).downto(0) do |i|
-        ix = Int64.cast(indices[i])
-        if ix.ndim != 1
-          raise DimensionError, "index array is not one-dimensional"
-        end
-        ix[ix < 0] += shape[i]
-        if ((ix < 0) & (ix >= shape[i])).any?
-          raise IndexError, "index array is out of range"
-        end
-        if idx
-          if idx.size != ix.size
-            raise ShapeError, "index array sizes mismatch"
-          end
-          idx += ix * stride
-          stride *= shape[i]
-        else
-          idx = ix
-          stride = shape[i]
-        end
-      end
-      self[idx]
-    end
-
     # Rotate in the plane specified by axes.
     # @example
     #   p a = Numo::Int32.new(2,2).seq

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -88,6 +88,19 @@ class NArrayTest < Test::Unit::TestCase
         assert { a[3..4] == [5,7] }
         assert { a[5] == 11 }
         assert { a[-1] == 11 }
+
+        assert { a.at([3, 4]) == [5,7] }
+        assert { a.view.at([3, 4]) == [5,7] }
+        assert { a[2..-1].at([1, 2]) == [5,7] }
+        assert { a.at(Numo::Int32.cast([3, 4])) == [5,7] }
+        assert { a.view.at(Numo::Int32.cast([3, 4])) == [5,7] }
+        assert { a.at(3..4) == [5,7] }
+        assert { a.view.at(3..4) == [5,7] }
+        assert { a.at([5]) == [11] }
+        assert { a.view.at([5]) == [11] }
+        assert { a.at([-1]) == [11] }
+        assert { a.view.at([-1]) == [11] }
+
         assert { a[(0..-1).each] == [1,2,3,5,7,11] }
         assert { a[(0...-1).each] == [1,2,3,5,7] }
 
@@ -244,6 +257,20 @@ class NArrayTest < Test::Unit::TestCase
         assert { a[1,2] == src[1][2] }
         assert { a[3..4] == [5,7] }
         assert { a[0,1..2] == [2,3] }
+
+        assert { a.at([0,1],[1,2]) == [2,11] }
+        assert { a.view.at([0,1],[1,2]) == [2,11] }
+        assert { a.at([0,1],(0..2) % 2) == [1,11] }
+        assert { a.view.at([0,1],(0..2) % 2) == [1,11] }
+        assert { a.at((0..1) % 1,[0,2]) == [1,11] }
+        assert { a.view.at((0..1) % 1,[0,2]) == [1,11] }
+        assert { a.at(Numo::Int32.cast([0,1]),Numo::Int32.cast([1,2])) == [2,11] }
+        assert { a.view.at(Numo::Int32.cast([0,1]),Numo::Int32.cast([1,2])) == [2,11] }
+        assert { a[[0,1],[0,2]].at([0,1],[0,1]) == [1,11] }
+        assert { a[[0,1],(0..2) % 2].at([0,1],[0,1]) == [1,11] }
+        assert { a[(0..1) % 1,[0,2]].at([0,1],[0,1]) == [1,11] }
+        assert { a[(0..1) % 1,(0..2) % 2].at([0,1],[0,1]) == [1,11] }
+
         assert { a[0,:*] == src[0] }
         assert { a[1,:*] == src[1] }
         assert { a[:*,1] == [src[0][1],src[1][1]] }
@@ -335,6 +362,9 @@ class NArrayTest < Test::Unit::TestCase
       assert_raise(IndexError) { a[1, 1, 1, 1, :rest] }
       assert_raise(IndexError) { a[1, 1, 1, :rest, 1] }
       assert_raise(IndexError) { a[:rest, 1, :rest, 0] }
+
+      assert { a.at([0,1],[1,0], [0,1]) == [3,6] }
+      assert { a.view.at([0,1],[1,0],[0,1]) == [3,6] }
 
       assert { a.transpose == [[[1,5],[3,7]],[[2,6],[4,8]]] }
       assert { a.transpose(2,1,0) == [[[1,5],[3,7]],[[2,6],[4,8]]] }
@@ -481,6 +511,21 @@ class NArrayTest < Test::Unit::TestCase
         assert { Numo::NMath.sqrt(a[1..9])         == [2, 3, 4, 5, 6, 7, 8, 9, 10] }
         assert { Numo::NMath.sqrt(a[1..9].inplace) == [2, 3, 4, 5, 6, 7, 8, 9, 10] }
       end
+    end
+
+    test "#{dtype},advanced indexing" do
+      a = dtype[[1,2,3],[4,5,6]]
+      assert { a[[0,1],[0,1]].dup == [[1,2],[4,5]] }
+      assert { a[[0,1],[0,1]].sum == 12 }
+      assert { a[[0,1],[0,1]].diagonal == [1, 5] }
+      diag = a.dup[[0,1],[0,1]].diagonal
+      diag.inplace - 1
+      assert { diag == [0, 4] }
+
+      assert { a.at([0,1],[0,1]).dup == [1, 5] }
+      at   = a.dup
+      at.at([0,1],[0,1]).inplace - 1
+      assert { at == [[0,2,3],[4,4,6]] }
     end
   end
 end


### PR DESCRIPTION
I rewrote the at() method using C language.
The result is up to x18 times faster.

## Ruby 2.5.3 (Linux)

* 0.9.2.1 : this PR(3df0b60870258a824e4d6f2e7e9f0e714d69ca9d)
<pre>
$  benchmark-driver diagonal_at_fp32_diff.yaml
Calculating -------------------------------------
                                                  numo-narray 0.9.1.4  numo-narray 0.9.2.1 
a.at(Array, Array)                                            546.533               9.840k i/s -      1.000k times in 1.829716s 0.101628s
l.at(Numo::Int32(X).seq,      Numo::Int32(X).seq)              2.203k               7.935k i/s -      1.000k times in 0.453879s 0.126025s

Comparison:
             a.at(Array, Array)                               
                              numo-narray 0.9.2.1:      9839.8 i/s 
                              numo-narray 0.9.1.4:       546.5 i/s - 18.00x  slower

             l.at(Numo::Int32(X).seq,      Numo::Int32(X).seq)
                              numo-narray 0.9.2.1:      7934.9 i/s 
                              numo-narray 0.9.1.4:      2203.2 i/s - 3.60x  slower
</pre>
## benchmark code
<pre>
$ cat diagonal_at_fp32_diff.yaml
contexts:
  - gems: { numo-narray: 0.9.1.4 }
    require: false
    prelude: |
      require 'numo/narray'
  - gems: { numo-narray: 0.9.2.1 }
    require: false
    prelude: |
      require 'numo/narray'
loop_count: 1000
prelude: |
  require 'numo/narray'
  X = 10000
  a = Numo::SFloat.new(X, X).seq(0)
  b = Numo::SFloat.new(X, X).seq(0)
  x = Numo::Int32.new(X).seq.to_a
  y = Numo::Int32.new(X).seq
  sleep 30

benchmark:
  'a.at(Array, Array)                               '      : a.at(x, x)
  'l.at(Numo::Int32(X).seq,      Numo::Int32(X).seq)'      : b.at(y, y)
</pre>