### PR TITLE
Add support for Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 language:
   ruby
 
-rvm:
-  - '2.2'
-  - '2.3'
-  - '2.4'
-  - '2.5'
-  - '2.6'
-
 matrix:
   fast_finish: true
+  include:
+    - rvm: '2.2'
+    - rvm: '2.3'
+    - rvm: '2.4'
+    - rvm: '2.5'
+    - rvm: '2.6'
+    - name: 'master'
+      rvm: 'ruby-head'
+      before_install: true
 
 notifications:
   email: false

--- a/ext/numo/narray/index.c
+++ b/ext/numo/narray/index.c
@@ -1050,11 +1050,8 @@ static VALUE na_slice(int argc, VALUE *argv, VALUE self)
       #  [10, 11, 99, 13, 14],
       #  [15, 16, 99, 18, 19]]
  */
-static VALUE na_aref(int argc, VALUE *argv, VALUE self)
-{
-    // implemented in subclasses
-    return rb_f_notimplement(argc,argv,self);
-}
+// implemented in subclasses
+#define na_aref rb_f_notimplement
 
 /*
   Multi-dimensional element assignment.
@@ -1094,11 +1091,8 @@ static VALUE na_aref(int argc, VALUE *argv, VALUE self)
       #  [8, 9, 10, 11]]
 
 */
-static VALUE na_aset(int argc, VALUE *argv, VALUE self)
-{
-    // implemented in subclasses
-    return rb_f_notimplement(argc,argv,self);
-}
+// implemented in subclasses
+#define na_aset rb_f_notimplement
 
 /*
   Multi-dimensional array indexing.


### PR DESCRIPTION
rb_f_notimplement() signature was changed by
https://github.com/ruby/ruby/commit/9ef51b0b89a10c8c401cb9f2337e47a25be72cbe
.

If we use rb_f_notimplement() directly instead of delegating to
rb_f_notimplement(), we can use the same code for Ruby 2.7 or earlier.