### PR TITLE
Add support for copy on write with store_binary and frozen string

### DIFF
--- a/ext/numo/narray/gen/tmpl/alloc_func.c
+++ b/ext/numo/narray/gen/tmpl/alloc_func.c
@@ -29,7 +29,9 @@ static void
     assert(na->base.type == NARRAY_DATA_T);
 
     if (na->ptr != NULL) {
-        xfree(na->ptr);
+        if (na->owned) {
+            xfree(na->ptr);
+        }
         na->ptr = NULL;
     }
     if (na->base.size > 0) {
@@ -103,5 +105,6 @@ static VALUE
     na->base.shape = NULL;
     na->base.reduce = INT2FIX(0);
     na->ptr = NULL;
+    na->owned = FALSE;
     return TypedData_Wrap_Struct(klass, &<%=type_name%>_data_type, (void*)na);
 }

--- a/ext/numo/narray/gen/tmpl/allocate.c
+++ b/ext/numo/narray/gen/tmpl/allocate.c
@@ -20,6 +20,7 @@ static VALUE
             }
             <% end %>
             NA_DATA_PTR(na) = ptr;
+            NA_DATA_OWNED(na) = TRUE;
         }
         break;
     case NARRAY_VIEW_T:

--- a/ext/numo/narray/gen/tmpl_bit/allocate.c
+++ b/ext/numo/narray/gen/tmpl_bit/allocate.c
@@ -12,6 +12,7 @@ static VALUE
         if (na->size > 0 && ptr == NULL) {
             ptr = xmalloc(((na->size-1)/8/sizeof(BIT_DIGIT)+1)*sizeof(BIT_DIGIT));
             NA_DATA_PTR(na) = ptr;
+            NA_DATA_OWNED(na) = TRUE;
         }
         break;
     case NARRAY_VIEW_T:

--- a/ext/numo/narray/numo/narray.h
+++ b/ext/numo/narray/numo/narray.h
@@ -195,6 +195,7 @@ typedef struct RNArray {
 typedef struct RNArrayData {
     narray_t base;
     char    *ptr;
+    bool     owned;
 } narray_data_t;
 
 
@@ -323,6 +324,7 @@ _na_get_narray_t(VALUE obj, unsigned char na_type)
 #define NA_DATA(na)             ((narray_data_t*)(na))
 #define NA_VIEW(na)             ((narray_view_t*)(na))
 #define NA_DATA_PTR(na)         (NA_DATA(na)->ptr)
+#define NA_DATA_OWNED(na)       (NA_DATA(na)->owned)
 #define NA_VIEW_DATA(na)        (NA_VIEW(na)->data)
 #define NA_VIEW_OFFSET(na)      (NA_VIEW(na)->offset)
 #define NA_VIEW_STRIDX(na)      (NA_VIEW(na)->stridx)

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -531,5 +531,63 @@ class NArrayTest < Test::Unit::TestCase
       at.at([0,1],[0,1]).inplace - 1
       assert { at == [[0,2,3],[4,4,6]] }
     end
+
+    sub_test_case "#{dtype}.from_binary" do
+      test "frozen string" do
+        shape = [2, 5]
+        a = dtype.new(*shape)
+        a.rand(0, 10)
+        original_data = a.to_binary
+        data = original_data.dup.freeze
+        restored_a = dtype.from_binary(data, shape)
+        assert { restored_a == a }
+        restored_a[0, 0] += 1
+        assert { restored_a != a }
+        assert { data == original_data }
+      end
+
+      test "not frozen string" do
+        shape = [2, 5]
+        a = dtype.new(*shape)
+        a.rand(0, 10)
+        original_data = a.to_binary
+        data = original_data.dup
+        restored_a = dtype.from_binary(data, shape)
+        assert { restored_a == a  }
+        restored_a[0, 0] += 1
+        assert { restored_a != a }
+        assert { data == original_data }
+      end
+    end
+
+    sub_test_case "#{dtype}#store_binary" do
+      test "frozen string" do
+        shape = [2, 5]
+        a = dtype.new(*shape)
+        a.rand(0, 10)
+        original_data = a.to_binary
+        data = original_data.dup.freeze
+        restored_a = dtype.new(*shape)
+        restored_a.store_binary(data)
+        assert { restored_a == a }
+        restored_a[0, 0] += 1
+        assert { restored_a != a }
+        assert { data == original_data }
+      end
+
+      test "not frozen string" do
+        shape = [2, 5]
+        a = dtype.new(*shape)
+        a.rand(0, 10)
+        original_data = a.to_binary
+        data = original_data.dup
+        restored_a = dtype.new(*shape)
+        restored_a.store_binary(data)
+        assert { restored_a == a }
+        restored_a[0, 0] += 1
+        assert { restored_a != a }
+        assert { data == original_data }
+      end
+    end
   end
 end


### PR DESCRIPTION
It reduces memory usage when NArray just uses data as read only data
because store_binary doesn't copy the passed binary data until NArray
writes the passed binary data.

Benchamrk:

    require "numo/narray"

    GC.disable

    shape = [100, 100]
    array = Numo::Int32.new(*shape).seq
    data = array.to_binary
    frozen_data = array.to_binary.freeze
    marshaled_data = Marshal.dump(array)

    def report_memory_usage(label, previous)
      usage = File.readlines("/proc/self/status").grep(/^VmRSS/)[0][/^VmRSS:\s*(\d+)/, 1].to_i
      puts "#{label}: #{usage - previous} kB"
      usage
    end

    usage = report_memory_usage("initial", 0)

    10000.times do
      Numo::Int32.new(*shape).seq
    end
    usage = report_memory_usage("seq", usage)

    10000.times do
      Numo::Int32.from_binary(data, shape)
    end
    usage = report_memory_usage("from not frozen data", usage)

    10000.times do
      Numo::Int32.from_binary(frozen_data, shape)
    end
    usage = report_memory_usage("from frozen data", usage)

    10000.times do
      Numo::Int32.from_binary(frozen_data, shape)[0, 0] = 1
    end
    usage = report_memory_usage("from frozen data with write", usage)

    10000.times do
      Marshal.load(marshaled_data)
    end
    usage = report_memory_usage("marshal", usage)

With this change:

    initial: 16488 kB
    seq: 393360 kB
    from not frozen data: 392040 kB
    from frozen data: 1848 kB
    from frozen data with write: 392660 kB
    marshal: 396528 kB

Without this change:

    initial: 16276 kB
    seq: 393360 kB
    from not frozen data: 391776 kB
    from frozen data: 392040 kB
    from frozen data with write: 392040 kB
    marshal: 786456 kB

See "fron frozen data" entry. It reduces memory usage from 392040 kB
to 1848 kB (0.4%).

See also "marshal" entry. It reduces memory usage from 786456 kB
to 396528 kB (50%).