### PR TITLE
[README] Simplify the README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Numo::NArray - New NArray class library for Ruby/Numo (NUmerical MOdule)
+# Numo::NArray
 
 [![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/repo/ruby-numo/numo-narray)
 [![Build Status](https://travis-ci.org/ruby-numo/numo-narray.svg?branch=master)](https://travis-ci.org/ruby-numo/numo-narray)


### PR DESCRIPTION
The title of Numo::NArray README is informative. That's a good thing. 
But as a design, it looks a little busy. Why don't we simplify it? 
This is just a suggestion to make README looks clean...

Thank you.