### PR TITLE
Adds percentile method

### DIFF
--- a/lib/numo/narray/extra.rb
+++ b/lib/numo/narray/extra.rb
@@ -1171,6 +1171,33 @@ module Numo
       end
     end
 
+    # Percentile
+    #
+    # @param q [Numo::NArray]
+    # @param axis [Integer] applied axis
+    # @return [Numo::NArray]  return percentile
+    def percentile(q, axis: nil)
+      x = self
+      unless axis
+        axis = 0
+        x = x.flatten
+      end
+
+      sorted = x.sort(axis: axis)
+      x = q / 100.0 * (sorted.shape[axis] - 1)
+      r = x % 1
+      i = x.floor
+      refs = [true] * sorted.ndim
+      refs[axis] = i
+      if i == sorted.shape[axis] - 1
+        sorted[*refs]
+      else
+        refs_upper = refs.dup
+        refs_upper[axis] = i + 1
+        sorted[*refs] + r * (sorted[*refs_upper] - sorted[*refs])
+      end
+    end
+
     # Kronecker product of two arrays.
     #
     #     kron(a,b)[k_0, k_1, ...] = a[i_0, i_1, ...] * b[j_0, j_1, ...]

--- a/lib/numo/narray/extra.rb
+++ b/lib/numo/narray/extra.rb
@@ -1177,6 +1177,8 @@ module Numo
     # @param axis [Integer] applied axis
     # @return [Numo::NArray]  return percentile
     def percentile(q, axis: nil)
+      raise ArgumentError, "q is out of range" if q < 0 || q > 100
+
       x = self
       unless axis
         axis = 0

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -333,6 +333,15 @@ class NArrayTest < Test::Unit::TestCase
           assert { a[:*,(a[0,:*]%2).eq(1)] == [[1,3],[5,11]] }
           assert { a.sort == src }
           assert { a.sort_index == [[0,1,2],[3,4,5]] }
+          assert { a.percentile(0) == 1.0 }
+          assert { a.percentile(50) == 4.0 }
+          assert { a.percentile(100) == 11.0 }
+          assert { a.percentile(0, axis: 0) == [1, 2, 3] }
+          assert { a.percentile(50, axis: 0) == [3, 4.5, 7] }
+          assert { a.percentile(100, axis: 0) == [5, 7, 11] }
+          assert { a.percentile(0, axis: 1) == [1, 5] }
+          assert { a.percentile(50, axis: 1) == [2, 7] }
+          assert { a.percentile(100, axis: 1) == [3, 11] }
         end
         assert { a.dup.fill(12) == [[12]*3]*2 }
         assert { (a + 1) == [[2,3,4],[6,8,12]] }


### PR DESCRIPTION
Adds `percentile` method.

```ruby
a = [[1,2,3],[5,7,11]]
a.percentile(50)
a.percentile(50, axis: 0)
a.percentile(50, axis: 1)
```

Uses the C = 1 variant for [percentile](https://en.wikipedia.org/wiki/Percentile) (same as NumPy).

NumPy test code

```py
import numpy as np

x = np.array([[1,2,3],[5,7,11]])
print(np.percentile(x, 0))
print(np.percentile(x, 50))
print(np.percentile(x, 100))
print(np.percentile(x, 0, axis=0))
print(np.percentile(x, 50, axis=0))
print(np.percentile(x, 100, axis=0))
print(np.percentile(x, 0, axis=1))
print(np.percentile(x, 50, axis=1))
print(np.percentile(x, 100, axis=1))
```