### PR TITLE
Use File.write in cogen to ensure file is closed

### DIFF
--- a/ext/numo/narray/gen/cogen.rb
+++ b/ext/numo/narray/gen/cogen.rb
@@ -66,7 +66,7 @@ code = DefLib.new do
 end.result
 
 if $output
-  open($output,"w").write(code)
+  File.write($output, code)
 else
   $stdout.write(code)
 end


### PR DESCRIPTION
The current usage of `open` will not close the file.