### PR TITLE
Use rake-compiler to make development a bit easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ tmp
 *~
 *.o
 *.so
+*.bundle
 mkmf.log
 ext/numo/narray/t_*.c
 ext/numo/narray/numo/extconf.h

--- a/Rakefile
+++ b/Rakefile
@@ -17,3 +17,6 @@ Rake::TestTask.new(:test) do |t|
   t.warning = false
   t.test_files = FileList['test/**/*_test.rb']
 end
+
+require 'rake/extensiontask'
+Rake::ExtensionTask.new('numo/narray')

--- a/numo-narray.gemspec
+++ b/numo-narray.gemspec
@@ -34,5 +34,6 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency "bundler", "~> 2.0"
   end
   spec.add_development_dependency "rake", ">= 12.3.3"
+  spec.add_development_dependency "rake-compiler", "~> 1.1"
   spec.add_development_dependency "test-unit", "~> 3.0"
 end


### PR DESCRIPTION
Just a suggestion, so feel free to close without comment if there's not any interest. This should make development a bit more standard as well as easier for Mac users (I believe it can eliminate the need for the custom setup scripts).

Edit - Here's the link: https://github.com/rake-compiler/rake-compiler

```sh
bundle exec rake compile
```

On Mac, the current `setup.rb` script doesn't return any errors, but doesn't appear to compile the extension.

```sh
ruby setup.rb compile
(ruby 2.7.1 x86_64-darwin18)

- - COMPILE - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 


```

Instead, my workflow as been:

```sh
ruby ext/numo/narray/extconf.rb
make
cp narray.bundle lib/numo/narray.bundle
```