### PR TITLE
Export nary_set_pointer method

### DIFF
--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -606,7 +606,7 @@ na_s_eye(int argc, VALUE *argv, VALUE klass)
 #define READ 1
 #define WRITE 2
 
-static void
+void
 na_set_pointer(VALUE self, char *ptr, size_t byte_size)
 {
     VALUE obj;

--- a/ext/numo/narray/narray.def
+++ b/ext/numo/narray/narray.def
@@ -11,6 +11,7 @@ nary_get_pointer_for_write
 nary_get_pointer_for_read
 nary_get_pointer_for_read_write
 nary_get_offset
+nary_set_pointer
 nary_copy_flags
 nary_check_ladder
 nary_check_contiguous

--- a/ext/numo/narray/numo/intern.h
+++ b/ext/numo/narray/numo/intern.h
@@ -44,6 +44,8 @@ char *nary_get_pointer_for_read(VALUE);
 char *nary_get_pointer_for_read_write(VALUE);
 #define na_get_offset nary_get_offset
 size_t nary_get_offset(VALUE self);
+#define na_set_pointer nary_set_pointer
+void nary_set_pointer(VALUE self, char *ptr, size_t byte_size);
 
 #define na_copy_flags nary_copy_flags
 void nary_copy_flags(VALUE src, VALUE dst);


### PR DESCRIPTION
Hi, this makes the `nary_set_pointer` method available to other gems. With this, I was able to create a bridge between Torch.rb and Numo where an update in one object is reflected in the other, just like PyTorch has a bridge with NumPy. Here's [the code](https://github.com/ankane/torch.rb/compare/numo_bridge_to) if you're interested.

I'm not very good with C, so there may be a better way to do this.