### PR TITLE
Add support for Ruby 3.0

### DIFF
--- a/numo-narray.gemspec
+++ b/numo-narray.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{alpha release of Numo::NArray - New NArray class library in Ruby/Numo (NUmerical MOdule)}
   spec.homepage      = "https://github.com/ruby-numo/numo-narray"
   spec.license       = "BSD-3-Clause"
-  spec.required_ruby_version = '~> 2.2'
+  spec.required_ruby_version = '>= 2.2'
 
   spec.files         = `git ls-files Gemfile README.md Rakefile lib ext numo-narray.gemspec spec`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
The next Ruby release will be 3.0.0: https://github.com/ruby/ruby/commit/21c62fb670b1646c5051a46d29081523cd782f11

The current `~> 2.2` `required_ruby_version` rejects `3.0.0`.
