### PR TITLE
Use rb_funcallv_kw function when calling method with keyword arguments

### DIFF
--- a/ext/numo/narray/gen/tmpl/accum_binary.c
+++ b/ext/numo/narray/gen/tmpl/accum_binary.c
@@ -94,7 +94,11 @@ static VALUE
         return <%=c_func%>_self(argc, argv, self);
     } else {
         v = rb_funcall(klass, id_cast, 1, self);
+        //<% if Gem::Version.create(RUBY_VERSION) < Gem::Version.create('2.7.0') %>
         return rb_funcall2(v, rb_intern("<%=name%>"), argc, argv);
+        //<% else %>
+        return rb_funcallv_kw(v, rb_intern("<%=name%>"), argc, argv, RB_PASS_CALLED_KEYWORDS);
+        //<% end %>
     }
     //<% end %>
 }

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -634,4 +634,14 @@ class NArrayTest < Test::Unit::TestCase
     x = Numo::RObject.cast([1.0, 2.0, 3.0]).sum
     assert{x == 6}
   end
+
+  test "#dot with different type arrays" do
+    $stderr = StringIO.new
+    a = Numo::Int32[1, 2, 3]
+    b = Numo::DFloat[[4], [5], [6]]
+    assert { a.dot(b).is_a?(Numo::DFloat) }
+    assert { a.dot(b) == [32] }
+    assert { $stderr.string == '' } # no warning message
+    $stderr = STDERR
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "numo/narray"
 require "test/unit"
+require "stringio"


### PR DESCRIPTION
This pull request fixes issue #184.
In Ruby 2.7 and later, it is preferable to use `rb_funcallv_kw` when calling method with keyword arguments. 

master branch:

```ruby
irb(main):001:0> require 'numo/narray'
=> true
irb(main):002:0> a=Numo::Int32[1,2,3]
=>
Numo::Int32#shape=[3]
...
irb(main):003:0> b=Numo::DFloat[[4],[5],[6]]
=>
Numo::DFloat#shape=[3,1]
...
irb(main):004:0> a.dot(b)
/Users/yoshoku/.anyenv/envs/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/numo-narray-0.9.1.9/lib/numo/narray/extra.rb:1116: warning: Using the last argument as keyword parameters is deprecated
=>
Numo::DFloat#shape=[1]
[32]
```

This PR:

```ruby
irb(main):001:0> require 'numo/narray'
=> true
irb(main):002:0> a=Numo::Int32[1,2,3]
=>
Numo::Int32#shape=[3]
...
irb(main):003:0> b=Numo::DFloat[[4],[5],[6]]
=>
Numo::DFloat#shape=[3,1]
...
irb(main):004:0> a.dot(b)
=>
Numo::DFloat#shape=[1]
[32]
```