### PR TITLE
Fix NMath.sinc(0)

### DIFF
--- a/ext/numo/narray/numo/types/complex_macro.h
+++ b/ext/numo/narray/numo/types/complex_macro.h
@@ -117,7 +117,7 @@ static inline dtype c_from_dcomplex(dcomplex x) {
 #define m_acosh(x)   c_acosh(x)
 #define m_atanh(x)   c_atanh(x)
 #define m_hypot(x,y) c_hypot(x,y)
-#define m_sinc(x)    c_div(c_sin(x),x)
+#define m_sinc(x)    (((x)==0) ? 1.0:(c_div(c_sin(x),x)))
 
 #define m_sum_init INT2FIX(0)
 #define m_mulsum_init INT2FIX(0)

--- a/ext/numo/narray/numo/types/complex_macro.h
+++ b/ext/numo/narray/numo/types/complex_macro.h
@@ -117,7 +117,7 @@ static inline dtype c_from_dcomplex(dcomplex x) {
 #define m_acosh(x)   c_acosh(x)
 #define m_atanh(x)   c_atanh(x)
 #define m_hypot(x,y) c_hypot(x,y)
-#define m_sinc(x)    (((x)==0) ? 1.0:(c_div(c_sin(x),x)))
+#define m_sinc(x)    c_div(c_sin(x),x)
 
 #define m_sum_init INT2FIX(0)
 #define m_mulsum_init INT2FIX(0)

--- a/ext/numo/narray/numo/types/complex_macro.h
+++ b/ext/numo/narray/numo/types/complex_macro.h
@@ -117,7 +117,7 @@ static inline dtype c_from_dcomplex(dcomplex x) {
 #define m_acosh(x)   c_acosh(x)
 #define m_atanh(x)   c_atanh(x)
 #define m_hypot(x,y) c_hypot(x,y)
-#define m_sinc(x)    ((REAL(x)==0 && IMAG(x)==0) ? (c_new(REAL(1), IMAG(0))):(c_div(c_sin(x),x)))
+#define m_sinc(x)    ((REAL(x)==0 && IMAG(x)==0) ? (c_new(1,0)):(c_div(c_sin(x),x)))
 
 #define m_sum_init INT2FIX(0)
 #define m_mulsum_init INT2FIX(0)

--- a/ext/numo/narray/numo/types/complex_macro.h
+++ b/ext/numo/narray/numo/types/complex_macro.h
@@ -117,7 +117,7 @@ static inline dtype c_from_dcomplex(dcomplex x) {
 #define m_acosh(x)   c_acosh(x)
 #define m_atanh(x)   c_atanh(x)
 #define m_hypot(x,y) c_hypot(x,y)
-#define m_sinc(x)    c_div(c_sin(x),x)
+#define m_sinc(x)    ((REAL(x)==0 && IMAG(x)==0) ? (c_new(REAL(1), IMAG(0))):(c_div(c_sin(x),x)))
 
 #define m_sum_init INT2FIX(0)
 #define m_mulsum_init INT2FIX(0)

--- a/ext/numo/narray/numo/types/float_macro.h
+++ b/ext/numo/narray/numo/types/float_macro.h
@@ -110,7 +110,7 @@ extern double pow(double, double);
 #define m_atanh(x)   atanh(x)
 #define m_atan2(x,y) atan2(x,y)
 #define m_hypot(x,y) hypot(x,y)
-#define m_sinc(x)    (sin(x)/(x))
+#define m_sinc(x)    (((x)==0) ? 1.0:(sin(x)/(x)))
 
 #define m_erf(x)     erf(x)
 #define m_erfc(x)    erfc(x)


### PR DESCRIPTION
Currently, `numpy.sinc(0.0)` returns 1.0, while `Numo::NMath.sinc(0.0)` returns NAN.
In this patch allows to return 1.0 in `Numo::NMath.sinc(0.0)`, just like `numpy.sinc(0.0)`.