### PR TITLE
Align lines of code

### DIFF
--- a/ext/numo/narray/gen/def/bit.rb
+++ b/ext/numo/narray/gen/def/bit.rb
@@ -6,17 +6,17 @@ set class_alias:         nil
 set class_var:           "cT"
 set ctype:               "BIT_DIGIT"
 
-set has_math:      false
-set is_bit:        true
-set is_int:        false
-set is_unsigned:   true
-set is_float:      false
-set is_complex:    false
-set is_object:     false
-set is_real:       false
-set is_comparable: false
+set has_math:            false
+set is_bit:              true
+set is_int:              false
+set is_unsigned:         true
+set is_float:            false
+set is_complex:          false
+set is_object:           false
+set is_real:             false
+set is_comparable:       false
 set is_double_precision: false
-set need_align:    false
+set need_align:          false
 
 upcast_rb "Integer"
 upcast_rb "Float", "DFloat"


### PR DESCRIPTION
Hi.
I am looking at the source code of numo-narray now.
I noticed that among the files in the def directory, only bit.rb does not align the lines. I think this is probably not intentional. This is just a minor style correction, but it would be nice if you could merge it.
Thank you.