### PR TITLE
Ractor support

### DIFF
--- a/ext/numo/narray/gen/tmpl/alloc_func.c
+++ b/ext/numo/narray/gen/tmpl/alloc_func.c
@@ -87,7 +87,7 @@ static const rb_data_type_t <%=type_name%>_data_type = {
     {0, <%=type_name%>_free, <%=type_name%>_memsize,},
     &na_data_type,
     &<%=type_name%>_info,
-    0, // flags
+    RUBY_TYPED_FROZEN_SHAREABLE, // flags
 };
 
 <% end %>

--- a/ext/numo/narray/gen/tmpl/init_class.c
+++ b/ext/numo/narray/gen/tmpl/init_class.c
@@ -14,6 +14,7 @@
     rb_hash_aset(hCast, rb_cArray,   cT);
     <% for x in upcast %>
     <%= x %><% end %>
+    rb_obj_freeze(hCast);
 
     <% @children.each do |m| %>
     <%= m.init_def %><% end %>

--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -1989,6 +1989,10 @@ na_equal(VALUE self, volatile VALUE other)
 void
 Init_narray()
 {
+#ifdef HAVE_RB_EXT_RACTOR_SAFE
+    rb_ext_ractor_safe(true);
+#endif
+
     mNumo = rb_define_module("Numo");
 
     /*

--- a/ext/numo/narray/numo/narray.h
+++ b/ext/numo/narray/numo/narray.h
@@ -450,6 +450,12 @@ typedef unsigned int BIT_DIGIT;
 #include "numo/ndloop.h"
 #include "numo/intern.h"
 
+// for Ractor support code
+#ifndef HAVE_RB_EXT_RACTOR_SAFE
+#   undef RUBY_TYPED_FROZEN_SHAREABLE
+#   define RUBY_TYPED_FROZEN_SHAREABLE 0
+#endif
+
 #if defined(__cplusplus)
 #if 0
 { /* satisfy cc-mode */

--- a/numo-narray.gemspec
+++ b/numo-narray.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   end
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rake-compiler", "~> 1.1"
-  spec.add_development_dependency "test-unit", "~> 3.0"
+  spec.add_development_dependency "test-unit"
 end

--- a/test/ractor_test.rb
+++ b/test/ractor_test.rb
@@ -1,52 +1,50 @@
 require_relative "test_helper"
 
 class NArrayRactorTest < NArrayTestBase
-  def setup
-    super
-    omit "Require Ractor" unless defined? Ractor
-  end
-
-  data(:dtype, TYPES, keep: true)
-  def test_non_frozen(data)
-    dtype = data.fetch(:dtype)
-    ary = random_array(dtype)
-    r = Ractor.new(ary) {|x| x }
-    ary2 = r.take
-    assert_equal(ary, ary2)
-    assert_not_same(ary, ary2)
-  end
-
-  def test_frozen(data)
-    dtype = data.fetch(:dtype)
-    ary1 = random_array(dtype)
-    ary1.freeze
-    r = Ractor.new(ary1) do |ary2|
-      [ary2, ary2 * 10]
+  if respond_to?(:ractor)
+    ractor keep: true
+    data(:dtype, TYPES, keep: true)
+    def test_non_frozen(data)
+      dtype = data.fetch(:dtype)
+      ary = random_array(dtype)
+      r = Ractor.new(ary) {|x| x }
+      ary2 = r.take
+      assert_equal(ary, ary2)
+      assert_not_same(ary, ary2)
     end
-    ary2, res = r.take
-    assert_equal((dtype != Numo::RObject),
-                 ary1.equal?(ary2))
-    assert_equal(ary1*10, res)
-  end
 
-  def test_parallel(data)
-    dtype = data.fetch(:dtype)
-    ary1 = random_array(dtype, 100000)
-    r1 = Ractor.new(ary1) do |ary2|
-      ary2 * 10
+    def test_frozen(data)
+      dtype = data.fetch(:dtype)
+      ary1 = random_array(dtype)
+      ary1.freeze
+      r = Ractor.new(ary1) do |ary2|
+        [ary2, ary2 * 10]
+      end
+      ary2, res = r.take
+      assert_equal((dtype != Numo::RObject),
+                   ary1.equal?(ary2))
+      assert_equal(ary1*10, res)
     end
-    r2 = Ractor.new(ary1) do |ary4|
-      ary4 * 10
-    end
-    assert_equal(r1.take, r2.take)
-  end
 
-  def random_array(dtype, n=1000)
-    case dtype
-    when Numo::DFloat, Numo::SFloat, Numo::DComplex, Numo::SComplex
-      dtype.new(n).rand_norm
-    else
-      dtype.new(n).rand(10)
+    def test_parallel(data)
+      dtype = data.fetch(:dtype)
+      ary1 = random_array(dtype, 100000)
+      r1 = Ractor.new(ary1) do |ary2|
+        ary2 * 10
+      end
+      r2 = Ractor.new(ary1) do |ary4|
+        ary4 * 10
+      end
+      assert_equal(r1.take, r2.take)
+    end
+
+    def random_array(dtype, n=1000)
+      case dtype
+      when Numo::DFloat, Numo::SFloat, Numo::DComplex, Numo::SComplex
+        dtype.new(n).rand_norm
+      else
+        dtype.new(n).rand(10)
+      end
     end
   end
 end

--- a/test/ractor_test.rb
+++ b/test/ractor_test.rb
@@ -1,0 +1,51 @@
+require_relative "test_helper"
+
+class NArrayRactorTest < NArrayTestBase
+  def setup
+    super
+    skip unless defined? Ractor
+  end
+
+  data(:dtype, TYPES, keep: true)
+  def test_non_frozen(data)
+    dtype = data.fetch(:dtype)
+    ary = random_array(dtype)
+    r = Ractor.new(ary) {|x| x }
+    ary2 = r.take
+    assert_equal(ary, ary2)
+    assert_not_same(ary, ary2)
+  end
+
+  def test_frozen(data)
+    dtype = data.fetch(:dtype)
+    ary1 = random_array(dtype)
+    ary1.freeze
+    r = Ractor.new(ary1) do |ary2|
+      [ary2, ary2 * 10]
+    end
+    ary2, res = r.take
+    assert_same(ary1, ary2)
+    assert_equal(ary1*10, res)
+  end
+
+  def test_parallel(data)
+    dtype = data.fetch(:dtype)
+    ary1 = random_array(dtype, 100000)
+    r1 = Ractor.new(ary1) do |ary2|
+      ary2 * 10
+    end
+    r2 = Ractor.new(ary1) do |ary4|
+      ary4 * 10
+    end
+    assert_equal(r1.take, r2.take)
+  end
+
+  def random_array(dtype, n=1000)
+    case dtype
+    when Numo::DFloat, Numo::SFloat, Numo::DComplex, Numo::SComplex
+      dtype.new(n).rand_norm
+    else
+      dtype.new(n).rand(10)
+    end
+  end
+end

--- a/test/ractor_test.rb
+++ b/test/ractor_test.rb
@@ -3,7 +3,7 @@ require_relative "test_helper"
 class NArrayRactorTest < NArrayTestBase
   def setup
     super
-    skip unless defined? Ractor
+    omit "Require Ractor" unless defined? Ractor
   end
 
   data(:dtype, TYPES, keep: true)

--- a/test/ractor_test.rb
+++ b/test/ractor_test.rb
@@ -24,7 +24,8 @@ class NArrayRactorTest < NArrayTestBase
       [ary2, ary2 * 10]
     end
     ary2, res = r.take
-    assert_same(ary1, ary2)
+    assert_equal((dtype != Numo::RObject),
+                 ary1.equal?(ary2))
     assert_equal(ary1*10, res)
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,3 +2,25 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "numo/narray"
 require "test/unit"
 require "stringio"
+
+class NArrayTestBase < Test::Unit::TestCase
+  FLOAT_TYPES = [
+    Numo::DFloat,
+    Numo::DComplex,
+  ]
+
+  TYPES = [
+    *FLOAT_TYPES,
+    Numo::SFloat,
+    Numo::SComplex,
+    Numo::Int64,
+    Numo::Int32,
+    Numo::Int16,
+    Numo::Int8,
+    Numo::UInt64,
+    Numo::UInt32,
+    Numo::UInt16,
+    Numo::UInt8,
+    Numo::RObject,
+  ]
+end


### PR DESCRIPTION
I want to let numo-narray support Ractor in this pull request.

The following changes are made:

- Freeze `UPCAST` constants to make them sharable in non-main Ractors
- Make frozen narrays sharable with non-main Ractors except for instances of `Numo::RObject`

I keep `Numo::RObject` non-sharable because its instances can have compound objects such as `Array` and `Hash`.

@masa16 Could you please take a look?