### PR TITLE
CI: Add ruby-3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1' ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby }}


### PR DESCRIPTION
Happy New Year! @masa16 
I made a simple pull request to add Ruby 3.1 to the CI. I believe numo-narray is the best matrix calculation library in the Ruby world even with Ruby 3.1. Hope you will merge it. Thanks!