### PR TITLE
Use rb_cObject instead of rb_cData

### DIFF
--- a/ext/numo/narray/array.c
+++ b/ext/numo/narray/array.c
@@ -358,7 +358,7 @@ na_composition3_ary(VALUE ary, VALUE *ptype, VALUE *pshape, VALUE *pnary)
     VALUE dtype, dshape;
 
     mdai = na_mdai_alloc(ary);
-    vmdai = TypedData_Wrap_Struct(rb_cData, &mdai_data_type, (void*)mdai);
+    vmdai = TypedData_Wrap_Struct(rb_cObject, &mdai_data_type, (void*)mdai);
     if ( na_mdai_investigate(mdai, 1) ) {
         // empty
         dtype = update_type(ptype, numo_cInt32);
@@ -606,7 +606,7 @@ na_ary_composition_for_struct(VALUE nstruct, VALUE ary)
 
     mdai = na_mdai_alloc(ary);
     mdai->na_type = nstruct;
-    vmdai = TypedData_Wrap_Struct(rb_cData, &mdai_data_type, (void*)mdai);
+    vmdai = TypedData_Wrap_Struct(rb_cObject, &mdai_data_type, (void*)mdai);
     na_mdai_for_struct(mdai, 0);
     nc = na_compose_alloc();
     vnc = WrapCompose(nc);


### PR DESCRIPTION
Hello.
Thank you for maintaining this wonderful library.
Understanding the source code of Numo::NArray, even partially, has been a dream of mine since I started programming.

When I compiled NArray from the source code, I noticed the following warning.

```console
../../../../../ext/numo/narray/array.c:361:5: warning: ‘rb_cData’ is deprecated: by: rb_cObject.  Will be removed in 3.1. [-Wdeprecated-declarations]
  361 |     vmdai = TypedData_Wrap_Struct(rb_cData, &mdai_data_type, (void*)mdai);
      |     ^~~~~
```

https://github.com/ruby-numo/numo-narray/blob/6f5c91250c0cb948f6b811385d384c3f15af4dcd/ext/numo/narray/array.c#L361

So we created a pull request to change rb_cData to rb_cObject.
This is the first pull request for the Numo::NArray C code. Please check if this simple replacement is appropriate for NArray. Thank you in advance.

Best regards