### PR TITLE
Add Windows & macOS to CI, fix Ruby master issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,13 +3,16 @@ name: build
 on: [push, pull_request]
 
 jobs:
-  release-versions:
-    name: Build on ruby-${{ matrix.ruby }}
-    runs-on: ubuntu-latest
+  MRI:
+    name: ${{ matrix.os }} ruby-${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        os: [ubuntu-latest, macos-11, windows-2022]
+        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', head]
+        include:
+          - { os: windows-2022 , ruby: mswin }
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby }}
@@ -25,8 +28,8 @@ jobs:
       - name: Tests
         run: rake test
 
-  ruby-head:
-    name: Build on ruby-head
+  ruby-head-debug:
+    name: Build on ruby-head-debug
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:

--- a/ext/numo/narray/array.c
+++ b/ext/numo/narray/array.c
@@ -358,7 +358,7 @@ na_composition3_ary(VALUE ary, VALUE *ptype, VALUE *pshape, VALUE *pnary)
     VALUE dtype, dshape;
 
     mdai = na_mdai_alloc(ary);
-    vmdai = TypedData_Wrap_Struct(rb_cData, &mdai_data_type, (void*)mdai);
+    vmdai = TypedData_Wrap_Struct(rb_cObject, &mdai_data_type, (void*)mdai);
     if ( na_mdai_investigate(mdai, 1) ) {
         // empty
         dtype = update_type(ptype, numo_cInt32);
@@ -606,7 +606,7 @@ na_ary_composition_for_struct(VALUE nstruct, VALUE ary)
 
     mdai = na_mdai_alloc(ary);
     mdai->na_type = nstruct;
-    vmdai = TypedData_Wrap_Struct(rb_cData, &mdai_data_type, (void*)mdai);
+    vmdai = TypedData_Wrap_Struct(rb_cObject, &mdai_data_type, (void*)mdai);
     na_mdai_for_struct(mdai, 0);
     nc = na_compose_alloc();
     vnc = WrapCompose(nc);

--- a/lib/numo/narray.rb
+++ b/lib/numo/narray.rb
@@ -1,2 +1,2 @@
-require "numo/narray.so"
+require "numo/narray.#{RUBY_PLATFORM.include?('darwin') ? 'bundle' : 'so'}"
 require "numo/narray/extra"


### PR DESCRIPTION
Adds Windows and macOS CI jobs.  Ruby master/head testing is much better than in the past, as all the Ruby builds are fully tested on GitHub Actions.  With other CI systems, that was not the case.  Many repos are testing against the builds without 'allow-failure' setups.

Small update to array.c, same as #201 (gave co-author credit)

Closes #200
Closes #201

Passing CI - see https://github.com/MSP-Greg/numo-narray/actions/runs/2673530157