### PR TITLE
Allow convert nil to NaN when making Numo::DFloat

### DIFF
--- a/ext/numo/narray/numo/types/float_macro.h
+++ b/ext/numo/narray/numo/types/float_macro.h
@@ -12,7 +12,7 @@ extern double pow(double, double);
 #define m_zero 0.0
 #define m_one  1.0
 
-#define m_num_to_data(x) NUM2DBL(x)
+#define m_num_to_data(x) (NIL_P(x) ? nan("") : NUM2DBL(x))
 #define m_data_to_num(x) rb_float_new(x)
 
 #define m_from_double(x) (x)

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -644,4 +644,9 @@ class NArrayTest < Test::Unit::TestCase
     assert { $stderr.string == '' } # no warning message
     $stderr = STDERR
   end
+
+  test "Numo::DFloat.cast(Numo::RObject[1, nil, 3])" do
+    assert_equal(Numo::DFloat[1, Float::NAN, 3].format_to_a,
+                 Numo::DFloat.cast(Numo::RObject[1, nil, 3]).format_to_a)
+  end
 end


### PR DESCRIPTION
# Before

```
% irb -rnumo/narray
irb(main):001:0> Numo::DFloat[1, nil, 3]
(irb):1:in `[]': no implicit conversion to float from nil (TypeError)
        from (irb):1:in `<main>'
        from /Users/mrkn/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
        from /Users/mrkn/.rbenv/versions/3.1.2/bin/irb:25:in `load'
        from /Users/mrkn/.rbenv/versions/3.1.2/bin/irb:25:in `<main>'
irb(main):002:0> Numo::RObject[1, nil, 3].cast_to(Numo::DFloat)
(irb):2:in `cast': no implicit conversion to float from nil (TypeError)
        from (irb):2:in `cast_to'
        from (irb):2:in `<main>'
        from /Users/mrkn/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
        from /Users/mrkn/.rbenv/versions/3.1.2/bin/irb:25:in `load'
        from /Users/mrkn/.rbenv/versions/3.1.2/bin/irb:25:in `<main>'
irb(main):003:0>
```

# After

```
% irb -Ilib -rnumo/narray
irb(main):001:0> Numo::DFloat[1, nil, 3]
=>
Numo::DFloat#shape=[3]
[1, nan, 3]
irb(main):002:0> Numo::RObject[1, nil, 3].cast_to(Numo::DFloat)
=>
Numo::DFloat#shape=[3]
[1, nan, 3]
irb(main):003:0>
```

---

# TODO

- [ ] Add test cases of `Numo::SFloat` 