### PR TITLE
Fix ERB.new arguments

### DIFF
--- a/ext/numo/narray/gen/erbpp2.rb
+++ b/ext/numo/narray/gen/erbpp2.rb
@@ -70,7 +70,11 @@ class ErbPP
           if get(:line_number)
             erb = ERBLN.new(File.read(path), path, trim_mode)
           else
-            erb = ERB.new(File.read(path), safe_level, trim_mode)
+            if RUBY_VERSION < '2.6'
+              erb = ERB.new(File.read(path), safe_level, trim_mode)
+            else
+              erb = ERB.new(File.read(path), safe_level: safe_level, trim_mode: trim_mode)
+            end
             erb.filename = path
           end
           return erb


### PR DESCRIPTION
trim_mode must be passed as a keyword argument or a deprecation warning is shown. 
The current code will not work with Ruby 3.2 or higher.

https://docs.ruby-lang.org/ja/latest/class/ERB.html#S_NEW
> Ruby 2.6.0 から位置引数での safe_level, trim_mode, eoutvar の指定は非推奨です。 Ruby 3.2 で削除されました。 trim_mode と eoutvar の指定はキーワード引数に移行してください。 