### PR TITLE
Fix CI failures and improve Ruby 3.3 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
       - name: Build and Install
         run: |
-          gem install --no-document bundler
           gem build numo-narray.gemspec
           gem install numo-narray-*.gem
           bundle install
@@ -44,7 +43,6 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
       - name: Build and Install
         run: |
-          gem install --no-document bundler
           gem build numo-narray.gemspec
           gem install numo-narray-*.gem
           bundle install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         include:
           - { os: windows-2022 , ruby: mswin }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:
@@ -37,7 +37,7 @@ jobs:
       matrix:
         ruby: [ 'debug' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-11, windows-2022]
-        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', head]
+        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', head]
         include:
           - { os: windows-2022 , ruby: mswin }
     steps:

--- a/ext/numo/narray/extconf.rb
+++ b/ext/numo/narray/extconf.rb
@@ -88,6 +88,7 @@ unless have_type("u_int64_t", stdint)
 end
 have_func("exp10")
 have_func("rb_arithmetic_sequence_extract")
+have_func("RTYPEDDATA_GET_DATA")
 
 have_var("rb_cComplex")
 

--- a/ext/numo/narray/index.c
+++ b/ext/numo/narray/index.c
@@ -272,7 +272,7 @@ na_parse_enumerator_step(VALUE enum_obj, VALUE *pstep )
     if (!RB_TYPE_P(enum_obj, T_DATA)) {
         rb_raise(rb_eTypeError,"wrong argument type (not T_DATA)");
     }
-    e = (struct enumerator *)DATA_PTR(enum_obj);
+    e = RENUMERATOR_PTR(enum_obj);
 
     if (!rb_obj_is_kind_of(e->obj, rb_cRange)) {
         rb_raise(rb_eTypeError,"not Range object");
@@ -306,7 +306,7 @@ na_parse_enumerator(VALUE enum_obj, int orig_dim, ssize_t size, na_index_arg_t *
         rb_raise(rb_eTypeError,"wrong argument type (not T_DATA)");
     }
     na_parse_enumerator_step(enum_obj, &step);
-    e = (struct enumerator *)DATA_PTR(enum_obj);
+    e = RENUMERATOR_PTR(enum_obj);
     na_parse_range(e->obj, NUM2SSIZET(step), orig_dim, size, q); // e->obj : Range Object
 }
 

--- a/ext/numo/narray/numo/narray.h
+++ b/ext/numo/narray/numo/narray.h
@@ -301,6 +301,12 @@ _na_get_narray_t(VALUE obj, unsigned char na_type)
 #define RNARRAY_VIEW(val)       ((narray_view_t*)DATA_PTR(val))
 #define RNARRAY_FILEMAP(val)    ((narray_filemap_t*)DATA_PTR(val))
 
+#ifdef HAVE_RTYPEDDATA_GET_DATA
+#define RENUMERATOR_PTR(ptr)    ((struct enumerator *)RTYPEDDATA_GET_DATA(ptr))
+#else
+#define RENUMERATOR_PTR(ptr)    ((struct enumerator *)DATA_PTR(ptr))
+#endif
+
 #define RNARRAY_NDIM(val)       (RNARRAY(val)->ndim)
 #define RNARRAY_TYPE(val)       (RNARRAY(val)->type)
 #define RNARRAY_FLAG(val)       (RNARRAY(val)->flag)

--- a/ext/numo/narray/step.c
+++ b/ext/numo/narray/step.c
@@ -60,7 +60,7 @@ nary_step_array_index(VALUE obj, size_t ary_size,
         vstep = rb_ivar_get(obj, id_step);
     } else { // Enumerator
         na_parse_enumerator_step(obj, &vstep);
-        e = (struct enumerator *)DATA_PTR(obj);
+        e = RENUMERATOR_PTR(obj);
         obj =  e->obj; // Range
     }
 
@@ -208,7 +208,7 @@ nary_step_sequence( VALUE obj, size_t *plen, double *pbeg, double *pstep )
         vstep = rb_ivar_get(obj, id_step);
     } else { // Enumerator
         na_parse_enumerator_step(obj, &vstep);
-        e = (struct enumerator *)DATA_PTR(obj);
+        e = RENUMERATOR_PTR(obj);
         obj =  e->obj; // Range
     }
 

--- a/numo-narray.gemspec
+++ b/numo-narray.gemspec
@@ -28,11 +28,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions    = ["ext/numo/narray/extconf.rb"]
 
-  if RUBY_VERSION < '2.3' # Ruby 2.2.x
-    spec.add_development_dependency "bundler", "~> 1.3", "< 1.14.0"
-  else
-    spec.add_development_dependency "bundler", ">= 2.2.33"
-  end
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rake-compiler", "~> 1.1"
   spec.add_development_dependency "test-unit"


### PR DESCRIPTION
This PR will fix  CI failures and improve Ruby 3.3 support.

1. Remove bundler installation
  - It installs bundler without specifying the version in CI. But, it installs bundler which does not work with old Ruby, and it causes failure. So, this patch remove bundler installation and uses bundler bundled in Ruby.

2. Fix failure with Ruby 3.3
  - The method of getting pointers from TypedData structure has changed since Ruby 3.3. This PR follows that.