### PR TITLE
Fix GCC compilation issue on Fedora 43

### DIFF
--- a/ext/numo/narray/ndloop.c
+++ b/ext/numo/narray/ndloop.c
@@ -38,6 +38,8 @@ typedef struct NA_LOOP_XARGS {
     bool free_user_iter;   // alloc LARG(lp,j).iter=lp->xargs[j].iter
 } na_loop_xargs_t;
 
+struct NA_MD_LOOP;
+
 typedef struct NA_MD_LOOP {
     int  narg;
     int  nin;
@@ -56,7 +58,7 @@ typedef struct NA_MD_LOOP {
     VALUE  reduce;
     VALUE  loop_opt;
     ndfunc_t  *ndfunc;
-    void (*loop_func)();
+    void (*loop_func)(ndfunc_t*, struct NA_MD_LOOP*);
 } na_md_loop_t;
 
 #define LARG(lp,iarg) ((lp)->user.args[iarg])


### PR DESCRIPTION
Hello.
This is a pull request to fix #221.
Thank you.

> ## Fixed the compilation issue with numo-narray on Fedora 43.
> 
> - Added forward declaration of struct: `struct NA_MD_LOOP;`
> - Specified function pointer type: `void (*loop_func)(ndfunc_t*, struct NA_MD_LOOP*);`
> 
> Root Cause
> 
> - The struct was self-referencing
> - Function pointer type was imprecise
> - Newer GCC enforces stricter type checking, causing errors
> 
> This fix allows numo-narray to compile successfully on Fedora 43 environments.
> 
> ```diff
> diff --git a/ext/numo/narray/ndloop.c b/ext/numo/narray/ndloop.c
> index 7a3b74c..214f328 100644
> --- a/ext/numo/narray/ndloop.c
> +++ b/ext/numo/narray/ndloop.c
> @@ -38,6 +38,8 @@ typedef struct NA_LOOP_XARGS {
>      bool free_user_iter;   // alloc LARG(lp,j).iter=lp->xargs[j].iter
>  } na_loop_xargs_t;
>  
> +struct NA_MD_LOOP;
> +
>  typedef struct NA_MD_LOOP {
>      int  narg;
>      int  nin;
> @@ -56,7 +58,7 @@ typedef struct NA_MD_LOOP {
>      VALUE  reduce;
>      VALUE  loop_opt;
>      ndfunc_t  *ndfunc;
> -    void (*loop_func)();
> +    void (*loop_func)(ndfunc_t*, struct NA_MD_LOOP*);
>  } na_md_loop_t;
>  
>  #define LARG(lp,iarg) ((lp)->user.args[iarg])
> ```