### PR TITLE
Update GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,14 +5,12 @@ on: [push, pull_request]
 jobs:
   MRI:
     name: ${{ matrix.os }} ruby-${{ matrix.ruby }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-11, windows-2022]
-        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', head]
-        include:
-          - { os: windows-2022 , ruby: mswin }
+        os: ['ubuntu', 'macos', 'windows']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', head]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}


### PR DESCRIPTION
- Adding Ruby 3.4
- Remove Ruby 2.5
- Always use the latest OS