### PR TITLE
Use assert_in_delta for floating-point comparisons

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,14 +5,12 @@ on: [push, pull_request]
 jobs:
   MRI:
     name: ${{ matrix.os }} ruby-${{ matrix.ruby }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-11, windows-2022]
-        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', head]
-        include:
-          - { os: windows-2022 , ruby: mswin }
+        os: ['ubuntu', 'macos', 'windows']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', head]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}

--- a/test/narray_test.rb
+++ b/test/narray_test.rb
@@ -142,9 +142,9 @@ class NArrayTest < Test::Unit::TestCase
         assert { a.sum == 29 }
         if float_types.include?(dtype)
           assert { a.mean == 29.0/6 }
-          assert { a.var == 13.766666666666669 }
-          assert { a.stddev == 3.710345895825168 }
-          assert { a.rms == 5.901977069875258 }
+          assert_in_delta(a.var, 13.766666666666669, 1e-14)
+          assert_in_delta(a.stddev, 3.710345895825168, 1e-14)
+          assert_in_delta(a.rms, 5.901977069875258, 1e-14)
         end
         assert { a.dup.fill(12) == [12]*6 }
         assert { (a + 1) == [2,3,4,6,8,12] }


### PR DESCRIPTION
This is a pull request that fixes a problem that causes some tests to fail due to floating point errors on macOS.