### PR TITLE
Fix function pointer declaration for Windows Ruby 3.4 / Fedra43

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,14 +5,12 @@ on: [push, pull_request]
 jobs:
   MRI:
     name: ${{ matrix.os }} ruby-${{ matrix.ruby }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-11, windows-2022]
-        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', head]
-        include:
-          - { os: windows-2022 , ruby: mswin }
+        os: ['ubuntu', 'macos', 'windows']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', head]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}

--- a/ext/numo/narray/ndloop.c
+++ b/ext/numo/narray/ndloop.c
@@ -38,8 +38,6 @@ typedef struct NA_LOOP_XARGS {
     bool free_user_iter;   // alloc LARG(lp,j).iter=lp->xargs[j].iter
 } na_loop_xargs_t;
 
-typedef struct NA_MD_LOOP na_md_loop_t;
-
 typedef struct NA_MD_LOOP {
     int  narg;
     int  nin;
@@ -58,7 +56,7 @@ typedef struct NA_MD_LOOP {
     VALUE  reduce;
     VALUE  loop_opt;
     ndfunc_t  *ndfunc;
-    void (*loop_func)(ndfunc_t *, na_md_loop_t *);
+    void (*loop_func)(ndfunc_t *, struct NA_MD_LOOP *);
 } na_md_loop_t;
 
 #define LARG(lp,iarg) ((lp)->user.args[iarg])

--- a/ext/numo/narray/ndloop.c
+++ b/ext/numo/narray/ndloop.c
@@ -38,6 +38,8 @@ typedef struct NA_LOOP_XARGS {
     bool free_user_iter;   // alloc LARG(lp,j).iter=lp->xargs[j].iter
 } na_loop_xargs_t;
 
+typedef struct NA_MD_LOOP na_md_loop_t;
+
 typedef struct NA_MD_LOOP {
     int  narg;
     int  nin;
@@ -56,7 +58,7 @@ typedef struct NA_MD_LOOP {
     VALUE  reduce;
     VALUE  loop_opt;
     ndfunc_t  *ndfunc;
-    void (*loop_func)();
+    void (*loop_func)(ndfunc_t *, na_md_loop_t *);
 } na_md_loop_t;
 
 #define LARG(lp,iarg) ((lp)->user.args[iarg])


### PR DESCRIPTION
- Add forward declaration for `na_md_loop_t`
- Fix loop_func signature: `void (*)()` -> `void (*)(ndfunc_t *, na_md_loop_t *)`