### PR TITLE
Ignore auto-generated extconf.h in lib directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ ext/numo/narray/t_*.c
 ext/numo/narray/numo/extconf.h
 ext/numo/narray/Makefile
 ext/numo/narray/depend
+lib/numo/numo/extconf.h
 TAGS
 t.rb


### PR DESCRIPTION
Add `lib/numo/numo/extconf.h` to `.gitignore`.

- This file is generated by rake-compiler during `bundle exec rake compile`
- It was missed when rake-compiler was added in c0641fc (2020)
- Build-generated files should not be tracked in git

Thank you.