### PR TITLE
Use Ractor#value instead of take

### DIFF
--- a/test/ractor_test.rb
+++ b/test/ractor_test.rb
@@ -8,7 +8,8 @@ class NArrayRactorTest < NArrayTestBase
       dtype = data.fetch(:dtype)
       ary = random_array(dtype)
       r = Ractor.new(ary) {|x| x }
-      ary2 = r.take
+      # Use Ractor#value in Ruby 3.5+, fallback to #take for older versions
+      ary2 = r.respond_to?(:value) ? r.value : r.take
       assert_equal(ary, ary2)
       assert_not_same(ary, ary2)
     end
@@ -20,7 +21,8 @@ class NArrayRactorTest < NArrayTestBase
       r = Ractor.new(ary1) do |ary2|
         [ary2, ary2 * 10]
       end
-      ary2, res = r.take
+      # Use Ractor#value in Ruby 3.5+, fallback to #take for older versions
+      ary2, res = r.respond_to?(:value) ? r.value : r.take
       assert_equal((dtype != Numo::RObject),
                    ary1.equal?(ary2))
       assert_equal(ary1*10, res)
@@ -35,7 +37,10 @@ class NArrayRactorTest < NArrayTestBase
       r2 = Ractor.new(ary1) do |ary4|
         ary4 * 10
       end
-      assert_equal(r1.take, r2.take)
+      # Use Ractor#value in Ruby 3.5+, fallback to #take for older versions
+      result1 = r1.respond_to?(:value) ? r1.value : r1.take
+      result2 = r2.respond_to?(:value) ? r2.value : r2.take
+      assert_equal(result1, result2)
     end
 
     def random_array(dtype, n=1000)


### PR DESCRIPTION
- [Ractor#take has been deprecated](https://github.com/ruby/ruby/pull/13512), replace it with value.
- This will allow the test to pass with the latest [ruby-head](https://github.com/ruby-numo/numo-narray/actions/runs/15370356103/job/43248613304).
