### PR TITLE
Fedora CI: Simplify build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,30 +50,17 @@ jobs:
   Fedora:
     name: fedora
     runs-on: ubuntu-latest
+    container: fedora:rawhide
     steps:
-      - name: Setup Podman
+      - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt-get -y install podman
-          podman pull fedora:rawhide
-      - name: Get source
-        uses: actions/checkout@v4
-        with:
-          path: 'numo-narray'
-      - name: Create container and run tests
+          dnf -y update
+          dnf -y install gcc-c++ git ruby-devel make
+          dnf clean all
+      - uses: actions/checkout@v5
+      - name: Build and test
         run: |
-          {
-              echo 'FROM fedora:rawhide'
-              echo 'RUN dnf -y update'
-              echo 'RUN dnf -y install gcc-c++ git ruby-devel'
-              echo 'RUN dnf clean all'
-              echo 'COPY numo-narray numo-narray'
-              echo 'WORKDIR /numo-narray'
-              echo 'RUN gem install --no-document bundler'
-              echo 'RUN gem build numo-narray.gemspec'
-              echo 'RUN gem install numo-narray-*.gem'
-              echo 'RUN bundle install'
-              echo 'RUN bundle exec rake compile'
-              echo 'RUN bundle exec rake test'
-          } > podmanfile
-          podman build --tag fedora_test -f ./podmanfile
+          gem install --no-document bundler
+          bundle install
+          bundle exec rake compile
+          bundle exec rake test


### PR DESCRIPTION
Current Fedora tests using Podman fail.
Let's change the standard GitHub Actions script to run tests more simply.